### PR TITLE
Roomupkeeper - upkeeping given conditions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
             <artifactId>google-api-services-calendar</artifactId>
             <version>v3-rev305-1.23.0</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-math3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/hvac/coordinator/CoordinatorAgent.java
+++ b/src/main/java/hvac/coordinator/CoordinatorAgent.java
@@ -5,12 +5,9 @@ import hvac.calendar.CalendarException;
 import hvac.calendar.CalendarWrapper;
 import hvac.coordinator.behaviours.MeetingUpdatingBehaviour;
 import hvac.database.Connection;
-import hvac.time.DateTimeSimulator;
 import jade.core.Agent;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import static hvac.util.Helpers.initTimeFromArgs;
 
 @SuppressWarnings("unused")
 public class CoordinatorAgent extends Agent {
@@ -19,7 +16,7 @@ public class CoordinatorAgent extends Agent {
     CoordinatorContext context = new CoordinatorContext();
     @Override
     protected void setup() {
-        initTimeFromArgs();
+        if(!initTimeFromArgs(this, this::usage)) return;
         database = new Connection();
         CalendarWrapper wrapper = new CalendarWrapper();
         try {
@@ -31,26 +28,6 @@ public class CoordinatorAgent extends Agent {
             return;
         }
         this.addBehaviour(new MeetingUpdatingBehaviour(this, 1000, calendar, context));
-    }
-
-    private void initTimeFromArgs() {
-        if (getArguments() == null || getArguments().length != 2) {
-            usage("Wrong args num");
-            doDelete();
-            return;
-        }
-        LocalDateTime startTime;
-        float timeScale;
-        try {
-            timeScale = Float.parseFloat(getArguments()[0].toString());
-            startTime = LocalDateTime.parse(getArguments()[1].toString(),
-                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        } catch (NumberFormatException | DateTimeParseException e) {
-            usage(e.getMessage());
-            doDelete();
-            return;
-        }
-        DateTimeSimulator.init(startTime, timeScale);
     }
 
     private void usage(String err) {

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgent.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgent.java
@@ -1,0 +1,83 @@
+package hvac.roomupkeeper;
+
+import hvac.ontologies.machinery.MachineryOntology;
+import hvac.ontologies.meeting.Meeting;
+import hvac.ontologies.roomclimate.RoomClimateOntology;
+import hvac.ontologies.weather.WeatherOntology;
+import hvac.roomupkeeper.behaviours.ClimateUpkeepingBehaviour;
+import hvac.time.DateTimeSimulator;
+import hvac.util.Conversions;
+import jade.content.lang.sl.SLCodec;
+import jade.core.AID;
+import jade.core.Agent;
+import jade.domain.FIPANames;
+
+import static hvac.util.Helpers.initTimeFromArgs;
+
+@SuppressWarnings("unused")
+public class RoomUpkeeperAgent extends Agent {
+    @Override
+    protected void setup() {
+        if(!initTimeFromArgs(this, this::usage)) return;
+        getContentManager().registerLanguage(new SLCodec(),
+                FIPANames.ContentLanguage.FIPA_SL0);
+        getContentManager().registerOntology(RoomClimateOntology.getInstance());
+        getContentManager().registerOntology(MachineryOntology.getInstance());
+        getContentManager().registerOntology(WeatherOntology.getInstance());
+
+        RoomUpkeeperContext context = getContext();
+        if(context == null) {
+            doDelete();
+            return;
+        }
+        context.getLogger().setAgentName("room upkeeper (" + context.getMyRoomId() + ")");
+        addBehaviour(new ClimateUpkeepingBehaviour(this, context));
+        context.setNextMeeting(new Meeting(
+                "abc",
+                Conversions.toDate(DateTimeSimulator.getCurrentDate().plusHours(2)),
+                Conversions.toDate(DateTimeSimulator.getCurrentDate().plusHours(4)),
+                5,
+                300.0f));
+    }
+
+    private RoomUpkeeperContext getContext() {
+        AID weatherForecaster = new AID("forecaster", false);
+        AID simulationAgent = new AID("simulation", false);
+        if(getArguments().length != 4) {
+            usage("incorrect number of arguments, required:4, provided: " + getArguments().length);
+            return null;
+        }
+        int myRoomId;
+        try {
+            myRoomId = Integer.parseInt(getArguments()[2].toString());
+        } catch (NumberFormatException e) {
+            usage("roomId is not valid");
+            return null;
+        }
+        if(myRoomId < 0) {
+            usage("roomId is not valid");
+        }
+        float myRoomArea;
+        try {
+            myRoomArea = Float.parseFloat(getArguments()[3].toString());
+        } catch (NumberFormatException e) {
+            usage("room area is not valid");
+            return null;
+        }
+        if(myRoomArea <= 0.0f) {
+            usage("room area is not valid");
+            return null;
+        }
+        return new RoomUpkeeperContext(weatherForecaster,simulationAgent,myRoomId, myRoomArea);
+    }
+
+    private void usage(String err) {
+        System.err.println("-------- Room upkeeper agent usage --------------");
+        System.err.println("roomUpkeeper:hvac.roomUpkeeper.RoomUpkeeperAgent(timeScale, start_date, roomId, roomArea)");
+        System.err.println("timescale - floating point value indicating speed of passing time");
+        System.err.println("Date from which to start simulating \"yyyy-MM-dd HH:mm:ss\"");
+        System.err.println("id of a room that will be upkept by this agent");
+        System.err.println("area in m^2 of a room that will be upkept by this agent");
+        System.err.println("err:" + err);
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
@@ -1,0 +1,65 @@
+package hvac.roomupkeeper;
+
+import hvac.ontologies.meeting.Meeting;
+import hvac.util.Logger;
+import jade.core.AID;
+
+public class RoomUpkeeperContext {
+    private final AID weatherForecaster;
+    private final AID simulationAgent;
+    private final int myRoomId;
+
+    /**
+     * Next meeting that will be held in this room
+     * room will be accomodated to its required conditions
+     * is null if no new meeting is scheduled
+     */
+    private Meeting nextMeeting;
+    private static final float relativeHumidityToMaintain = 0.5f;
+    private final float myRoomArea;
+
+    private final static float perPersonRequiredVentilation = 0.0025f;//2.5L/s = 0.0025m^3/s
+    private final static float perM2RequiredVentilation = 0.0003f;//0.3L/s/m^2 = 0.0003m^3/s/m^2
+    private final Logger logger = new Logger();
+
+    public RoomUpkeeperContext(AID weatherForecaster, AID simulationAgent, int myRoomId, float myRoomArea) {
+        this.weatherForecaster = weatherForecaster;
+        this.simulationAgent = simulationAgent;
+        this.myRoomId = myRoomId;
+        this.myRoomArea = myRoomArea;
+        this.nextMeeting = null;
+    }
+
+    public Meeting getNextMeeting() {
+        return nextMeeting;
+    }
+
+    public void setNextMeeting(Meeting nextMeeting) {
+        this.nextMeeting = nextMeeting;
+    }
+
+    public AID getWeatherForecaster() {
+        return weatherForecaster;
+    }
+
+    public AID getSimulationAgent() {
+        return simulationAgent;
+    }
+
+    public int getMyRoomId() {
+        return myRoomId;
+    }
+
+    public float getRelativeHumidityToMaintain() {
+        return relativeHumidityToMaintain;
+    }
+
+    public float getRequiredVentilation() {
+        return (nextMeeting != null ? perPersonRequiredVentilation*nextMeeting.getPeopleInRoom() : 0.0f)
+                + perM2RequiredVentilation * myRoomArea;
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
+++ b/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
@@ -1,0 +1,402 @@
+package hvac.roomupkeeper.behaviours;
+
+import hvac.ontologies.machinery.*;
+import hvac.ontologies.roomclimate.RoomClimate;
+import hvac.ontologies.weather.Forecast;
+import hvac.ontologies.weather.WeatherSnapshot;
+import hvac.roomupkeeper.RoomUpkeeperContext;
+import hvac.roomupkeeper.data.RoomStatus;
+import hvac.simulation.SimulationAgentMessenger;
+import hvac.time.DateTimeSimulator;
+import hvac.util.Conversions;
+import hvac.util.Helpers;
+import hvac.util.Interpolation;
+import hvac.weatherforecaster.WeatherForecasterMessenger;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
+import jade.core.Agent;
+import jade.core.behaviours.CyclicBehaviour;
+import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public class ClimateUpkeepingBehaviour extends CyclicBehaviour {
+    private final RoomUpkeeperContext context;
+    private Step step = Step.INIT;
+    private MessageTemplate currentTemplate;
+    private static final int CLIMATE_FORGET_TIME_SECONDS = 3600 * 2;
+    private static final int MINUTES_BETWEEN_UPDATES = 3;
+    private static final float AIR_QUALITY_TOLERANCE = 0.05f;
+    private static final float POWER_TOLERANCE = 0.5f;
+    private static final float AIR_EXCHAGEND_PER_SECOND_TOLERANCE = 0.1f;
+    private LocalDateTime lastUpdate = LocalDateTime.MIN;
+
+    private enum Step {
+        INIT,
+        CLIMATE_WAIT_FOR_RESPONSE,
+        MACHINERY_INFO_WAIT_FOR_RESPONSE,
+        MACHINERY_UPDATE_WAIT_FOR_RESPONSE,
+        WEATHER_FORECASTER_WAIT_FOR_RESPONSE
+    }
+
+    private RoomClimate currentClimate = null;
+    private final List<RoomStatus> roomStatuses = new ArrayList<>();
+
+    private Machinery currentMachinery = null;
+    private List<WeatherSnapshot> weatherSnapshots = new ArrayList<>();
+    private boolean started = false;
+
+    public ClimateUpkeepingBehaviour(Agent a, RoomUpkeeperContext context) {
+        super(a);
+        this.context = context;
+    }
+
+    @Override
+    public void action() {
+        if(!started) {
+            started = true;
+            block(1000);
+            return;
+        }
+        roomStatuses.removeIf(status->status.getTime()
+                .isBefore(DateTimeSimulator.getCurrentDate().minusSeconds(CLIMATE_FORGET_TIME_SECONDS)));
+        if(context.getNextMeeting() != null && Conversions.toLocalDateTime(context.getNextMeeting().getEndDate())
+                .isBefore(DateTimeSimulator.getCurrentDate())) {
+            context.setNextMeeting(null);
+        }
+        switch (step) {
+            case INIT:
+                initStep();
+                break;
+            case MACHINERY_INFO_WAIT_FOR_RESPONSE:
+                machineryInfoWaitForResponseStep();
+                break;
+            case WEATHER_FORECASTER_WAIT_FOR_RESPONSE:
+                weatherForecasterWaitForResponseStep();
+                break;
+            case CLIMATE_WAIT_FOR_RESPONSE:
+                climateWaitForResponseStep();
+                break;
+            case MACHINERY_UPDATE_WAIT_FOR_RESPONSE:
+                machineryUpdateWaitForResponseStep();
+        }
+    }
+
+    private void initStep() {
+        if (context.getNextMeeting() == null) {
+            block();
+            return;
+        }
+        calculateNextClimate();
+    }
+
+
+    private void machineryInfoWaitForResponseStep() {
+        ACLMessage msg = myAgent.receive(currentTemplate);
+        if (msg != null) {
+            try {
+                Optional<MachineryStatus> machineryStatusOpt = SimulationAgentMessenger.extractMachineryStatus(myAgent, msg);
+                machineryStatusOpt.ifPresent(status -> currentMachinery = status.getMachinery());
+                if (!machineryStatusOpt.isPresent()) {
+                    throw new RuntimeException("simulation agent returns incorrect messages");
+                }
+            } catch (Codec.CodecException | OntologyException e) {
+                e.printStackTrace();
+            }
+            calculateNextClimate();
+        } else {
+            block();
+        }
+    }
+
+    private void weatherForecasterWaitForResponseStep() {
+        ACLMessage msg = myAgent.receive(currentTemplate);
+        if (msg != null) {
+            try {
+                Optional<Forecast> forecastOpt = WeatherForecasterMessenger.extractForecast(myAgent, msg);
+                forecastOpt.ifPresent(forecast -> weatherSnapshots = Conversions.toJavaList(forecast.getWeatherSnapshots()));
+                if (!forecastOpt.isPresent()) {
+                    throw new RuntimeException("weather forecaster agent returns incorrect messages");
+                }
+            } catch (Codec.CodecException | OntologyException e) {
+                e.printStackTrace();
+            }
+            calculateNextClimate();
+        } else {
+            block();
+        }
+    }
+    private void climateWaitForResponseStep() {
+        ACLMessage msg = myAgent.receive(currentTemplate);
+        if (msg != null) {
+            try {
+                Optional<RoomClimate> roomClimateOpt = SimulationAgentMessenger.extractRoomClimate(myAgent, msg);
+                roomClimateOpt.ifPresent(climate -> {
+                    LocalDateTime currentDate = DateTimeSimulator.getCurrentDate();
+                    if (currentClimate != null) {
+                        roomStatuses.add(new RoomStatus(
+                                (climate.getTemperature() - currentClimate.getTemperature()) /
+                                        ChronoUnit.SECONDS.between(
+                                                lastUpdate,
+                                                currentDate),
+                                currentMachinery.getHeater().getHeatingPower().getCurrentValue() -
+                                        currentMachinery.getAirConditioner().getCoolingPower().getCurrentValue(),
+                                currentDate));
+                    }
+                    currentClimate = climate;
+                });
+                if (!roomClimateOpt.isPresent()) {
+                    throw new RuntimeException("Simulation agent returns incorrect messages");
+                }
+                if(roomStatuses.size() == 0) {
+                    //get some more data required to kickstart the interpolation process
+                    lastUpdate = DateTimeSimulator.getCurrentDate();
+                    calculateNextClimate();
+                    return;
+                } else if(roomStatuses.size() == 1) {
+                    //kickstart the interpolation process
+                    //first and last points need to
+                        roomStatuses.add(new RoomStatus(
+                                100.0f,
+                                10000000.0f,
+                                LocalDateTime.MAX));
+                        roomStatuses.add(new RoomStatus(
+                                -100.0f,
+                                -10000000.0f,
+                                LocalDateTime.MAX));
+                    }
+                updateMachinery();
+            } catch (Codec.CodecException | OntologyException e) {
+                e.printStackTrace();
+            }
+        } else {
+            block();
+        }
+    }
+
+    private void machineryUpdateWaitForResponseStep() {
+        ACLMessage msg = myAgent.receive(currentTemplate);
+        if (msg != null) {
+            if(msg.getPerformative() == ACLMessage.AGREE) {
+                step = Step.INIT;
+                lastUpdate = DateTimeSimulator.getCurrentDate();
+            }
+            calculateNextClimate();
+        } else {
+            block();
+        }
+    }
+
+    private void calculateNextClimate() {
+        if (context.getNextMeeting() == null) {
+            step = Step.INIT;
+            return;
+        }
+        if (currentMachinery == null) {
+            enterMachineryInfoWaitForResponseStep();
+        } else if (weatherSnapshots.stream().noneMatch(snapshot ->
+                Conversions.toLocalDateTime(snapshot.getTime())
+                        .isAfter(DateTimeSimulator.getCurrentDate().plusDays(2)))) {
+            enterWeatherForecasterWaitForResponseStep();
+        } else if(DateTimeSimulator.getCurrentDate().isBefore(lastUpdate.plusMinutes(MINUTES_BETWEEN_UPDATES))) {
+            long blockTime = (long) (ChronoUnit.MILLIS.between(DateTimeSimulator.getCurrentDate(),
+                                lastUpdate.plusMinutes(MINUTES_BETWEEN_UPDATES))/DateTimeSimulator.getTimeScale());
+            step = Step.INIT;
+            if(blockTime > 0)
+                block(blockTime);
+        }  else {
+            enterClimateWaitForResponseStep();
+        }
+    }
+
+    private void updateMachinery() {
+        Machinery machinery = prepareNextRequiredMachinery();
+        if (!(machinery.getHeater() == null
+                && machinery.getAirConditioner() == null
+                && machinery.getVentilator() == null)) {
+            Helpers.updateMachinery(currentMachinery, machinery);
+            enterMachineryUpdateWaitForResponseStep(machinery);
+        } else {
+            lastUpdate = DateTimeSimulator.getCurrentDate();
+            calculateNextClimate();
+        }
+    }
+
+    private Machinery prepareNextRequiredMachinery() {
+        float requiredTemperatureSlope = getRequiredTemperatureSlope();
+        float requiredHeatingPower = calculateRequiredHeatingPower(requiredTemperatureSlope);
+        return new Machinery(
+                prepareNextAirConditioner(requiredHeatingPower),
+                prepareNextHeater(requiredHeatingPower),
+                prepareNextVentilator()
+        );
+    }
+
+    private float getRequiredTemperatureSlope() {
+
+        if(meetingInProgress()) {
+            return (context.getNextMeeting().getTemperature()
+                    - currentClimate.getTemperature()) / ChronoUnit.SECONDS.between(
+                    DateTimeSimulator.getCurrentDate(),
+                    DateTimeSimulator.getCurrentDate().plusMinutes(MINUTES_BETWEEN_UPDATES));
+        }
+        else {
+            return (context.getNextMeeting().getTemperature()
+                    - currentClimate.getTemperature()) / ChronoUnit.SECONDS.between(
+                    DateTimeSimulator.getCurrentDate(),
+                    Conversions.toLocalDateTime(context.getNextMeeting().getStartDate()));
+        }
+    }
+
+    private AirConditioner prepareNextAirConditioner(float requiredHeatingPower) {
+        if (requiredHeatingPower < -POWER_TOLERANCE) {
+            return new AirConditioner(
+                    new MachineParameter(
+                            currentMachinery.getAirConditioner().getAirExchangedPerSecond().getMaxValue(), null),
+                    new MachineParameter(
+                            -requiredHeatingPower, null));
+        } else if (!Helpers.almostEqual(
+                0.0f,
+                currentMachinery.getHeater().getHeatingPower().getCurrentValue(),
+                POWER_TOLERANCE)) {
+            return new AirConditioner(
+                    new MachineParameter(
+                            0.0f, null),
+                    new MachineParameter(
+                            0.0f, null));
+        }
+        return null;
+    }
+
+    private Ventilator prepareNextVentilator() {
+        if (!Helpers.almostEqual(
+                currentMachinery.getVentilator().getAirExchangedPerSecond().getCurrentValue(),
+                context.getRequiredVentilation(),
+                AIR_EXCHAGEND_PER_SECOND_TOLERANCE)) {
+            if (currentClimate.getAirQuality() < 1-AIR_QUALITY_TOLERANCE &&
+                    !Helpers.almostEqual(
+                            currentMachinery.getVentilator().getAirExchangedPerSecond().getCurrentValue(),
+                            currentMachinery.getVentilator().getAirExchangedPerSecond().getMaxValue(),
+                            AIR_EXCHAGEND_PER_SECOND_TOLERANCE)) {
+                return new Ventilator(
+                        new MachineParameter(context.getRequiredVentilation(), null));
+            }
+            if (currentClimate.getAirQuality() > 1+AIR_QUALITY_TOLERANCE &&
+                    !Helpers.almostEqual(
+                            currentMachinery.getVentilator().getAirExchangedPerSecond().getCurrentValue(),
+                            0, AIR_EXCHAGEND_PER_SECOND_TOLERANCE)) {
+                return new Ventilator(
+                        new MachineParameter(context.getRequiredVentilation(), null));
+            }
+        }
+        return null;
+    }
+
+    private Heater prepareNextHeater(float requiredHeatingPower) {
+        if (requiredHeatingPower > POWER_TOLERANCE) {
+            return new Heater(new MachineParameter(
+                    requiredHeatingPower, null
+            ));
+        } else if (!Helpers.almostEqual(
+                0.0f,
+                currentMachinery.getHeater().getHeatingPower().getCurrentValue(),
+                POWER_TOLERANCE)) {
+            return new Heater(new MachineParameter(
+                    0.0f, null
+            ));
+        }
+        return null;
+    }
+
+    private float calculateRequiredHeatingPower(float requiredTemperatureSlope) {
+        List<Float> arguments = new ArrayList<>();
+        List<Float> values = new ArrayList<>();
+        roomStatuses.stream()
+                .sorted(Comparator.comparing(RoomStatus::getTemperatureSlope))
+                .forEachOrdered(status-> {
+                    arguments.add(status.getTemperatureSlope());
+                    values.add(status.getHeatingPower());
+                });
+        float unboundRequiredHeatingPower = Interpolation.calculateValueAt(requiredTemperatureSlope,
+                arguments, values);
+        return Math.max(Math.min(unboundRequiredHeatingPower,
+                currentMachinery.getHeater().getHeatingPower().getMaxValue()),
+                -currentMachinery.getAirConditioner().getAirExchangedPerSecond().getMaxValue());
+
+    }
+
+    private boolean meetingInProgress() {
+        return Conversions.toLocalDateTime(
+                context.getNextMeeting().getStartDate())
+                .isBefore(DateTimeSimulator.getCurrentDate())
+                && Conversions.toLocalDateTime(
+                context.getNextMeeting().getEndDate())
+                .isAfter(DateTimeSimulator.getCurrentDate());
+    }
+
+    private void enterMachineryInfoWaitForResponseStep() {
+        context.getLogger().log("entering MachineryInfoWaitForResponseStep");
+        try {
+            ACLMessage msg = SimulationAgentMessenger.prepareReportMachineryStatus(
+                    context.getMyRoomId(), myAgent, context.getSimulationAgent());
+            myAgent.send(msg);
+            currentTemplate = MessageTemplate.MatchSender(context.getSimulationAgent());
+            step = Step.MACHINERY_INFO_WAIT_FOR_RESPONSE;
+        } catch (Codec.CodecException | OntologyException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void enterWeatherForecasterWaitForResponseStep() {
+        context.getLogger().log("entering WeatherForecasterWaitForResponseStep");
+        try {
+            ACLMessage msg = WeatherForecasterMessenger.prepareForecastRequest(
+                    DateTimeSimulator.getCurrentDate(),
+                    DateTimeSimulator.getCurrentDate().plusWeeks(1),
+                    myAgent,
+                    context.getWeatherForecaster());
+            myAgent.send(msg);
+            currentTemplate = MessageTemplate.MatchSender(context.getWeatherForecaster());
+            step = Step.WEATHER_FORECASTER_WAIT_FOR_RESPONSE;
+        } catch (Codec.CodecException | OntologyException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void enterClimateWaitForResponseStep() {
+        context.getLogger().log("entering ClimateWaitForResponseStep");
+        try {
+            ACLMessage msg = SimulationAgentMessenger.prepareInfoRequest(
+                    context.getMyRoomId(),
+                    myAgent,
+                    context.getSimulationAgent());
+            myAgent.send(msg);
+            currentTemplate = MessageTemplate.MatchSender(context.getSimulationAgent());
+            step = Step.CLIMATE_WAIT_FOR_RESPONSE;
+        } catch (Codec.CodecException | OntologyException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void enterMachineryUpdateWaitForResponseStep(Machinery update) {
+        context.getLogger().log("entering MachineryUpdateWaitForResponseStep");
+        try {
+            ACLMessage msg = SimulationAgentMessenger.prepareUpdateMachinery(
+                    update,
+                    context.getMyRoomId(),
+                    myAgent,
+                    context.getSimulationAgent());
+            myAgent.send(msg);
+            currentTemplate = MessageTemplate.MatchSender(context.getSimulationAgent());
+            step = Step.MACHINERY_UPDATE_WAIT_FOR_RESPONSE;
+        } catch (Codec.CodecException | OntologyException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
+++ b/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
@@ -6,15 +6,15 @@ public class RoomStatus {
     private float temperatureSlope;
     private float humiditySlope;
     /**
-     * positive - power of the heater
-     * negative - power of the air conditioner
+     * positive -> heater.power=value, ac.power = 0
+     * negative -> heater.power = 0, ac.power = -value
      */
     private float heatingPower;
     /**
-     * positive - air exchanged per second by ventilation - minimal required ventilation
-     * negative - air exchanged per second by air conditioning - minimal required ventilation
-     * so it is zero when ventilation works on minimal required aeps
-     * and ac works enough to counteract humidification created by ventilation
+     * positive -> ac.airPerSecond = 0, ventilation.airPerSecond = value + minimalRequiredVentilation
+     * negative -> ac.airPerSecond = -value, ventilation.airPerSecond = minimalRequiredVentilation
+     * so its the same as with heating power -> ac counteracts ventilation - its just that the tipping point is not at zero
+     * but at minimalRequiredVentilation
      */
     private float airExchangedPerSecond;
     private LocalDateTime time;

--- a/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
+++ b/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
@@ -1,0 +1,39 @@
+package hvac.roomupkeeper.data;
+
+import java.time.LocalDateTime;
+
+public class RoomStatus {
+    private float temperatureSlope;
+    private float heatingPower;
+    private LocalDateTime time;
+
+    public RoomStatus(float temperatureSlope, float heatingPower, LocalDateTime time) {
+        this.temperatureSlope = temperatureSlope;
+        this.heatingPower = heatingPower;
+        this.time = time;
+    }
+
+    public float getTemperatureSlope() {
+        return temperatureSlope;
+    }
+
+    public void setTemperatureSlope(float temperatureSlope) {
+        this.temperatureSlope = temperatureSlope;
+    }
+
+    public float getHeatingPower() {
+        return heatingPower;
+    }
+
+    public void setHeatingPower(float heatingPower) {
+        this.heatingPower = heatingPower;
+    }
+
+    public LocalDateTime getTime() {
+        return time;
+    }
+
+    public void setTime(LocalDateTime time) {
+        this.time = time;
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
+++ b/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
@@ -4,12 +4,26 @@ import java.time.LocalDateTime;
 
 public class RoomStatus {
     private float temperatureSlope;
+    private float humiditySlope;
+    /**
+     * positive - power of the heater
+     * negative - power of the air conditioner
+     */
     private float heatingPower;
+    /**
+     * positive - air exchanged per second by ventilation - minimal required ventilation
+     * negative - air exchanged per second by air conditioning - minimal required ventilation
+     * so it is zero when ventilation works on minimal required aeps
+     * and ac works enough to counteract humidification created by ventilation
+     */
+    private float airExchangedPerSecond;
     private LocalDateTime time;
 
-    public RoomStatus(float temperatureSlope, float heatingPower, LocalDateTime time) {
+    public RoomStatus(float temperatureSlope, float humiditySlope, float heatingPower, float airExchangedPerSecond, LocalDateTime time) {
         this.temperatureSlope = temperatureSlope;
+        this.humiditySlope = humiditySlope;
         this.heatingPower = heatingPower;
+        this.airExchangedPerSecond = airExchangedPerSecond;
         this.time = time;
     }
 
@@ -35,5 +49,21 @@ public class RoomStatus {
 
     public void setTime(LocalDateTime time) {
         this.time = time;
+    }
+
+    public float getHumiditySlope() {
+        return humiditySlope;
+    }
+
+    public void setHumiditySlope(float humiditySlope) {
+        this.humiditySlope = humiditySlope;
+    }
+
+    public float getAirExchangedPerSecond() {
+        return airExchangedPerSecond;
+    }
+
+    public void setAirExchangedPerSecond(float airExchangedPerSecond) {
+        this.airExchangedPerSecond = airExchangedPerSecond;
     }
 }

--- a/src/main/java/hvac/simulation/SimulationAgentMessenger.java
+++ b/src/main/java/hvac/simulation/SimulationAgentMessenger.java
@@ -1,12 +1,9 @@
 package hvac.simulation;
 
-import hvac.ontologies.machinery.Machinery;
-import hvac.ontologies.machinery.MachineryOntology;
-import hvac.ontologies.machinery.ReportMachineryStatus;
-import hvac.ontologies.machinery.UpdateMachinery;
+import hvac.ontologies.machinery.*;
 import hvac.ontologies.roomclimate.InfoRequest;
 import hvac.ontologies.roomclimate.RoomClimate;
-import hvac.ontologies.weather.WeatherOntology;
+import hvac.ontologies.roomclimate.RoomClimateOntology;
 import jade.content.ContentElement;
 import jade.content.lang.Codec;
 import jade.content.onto.Ontology;
@@ -32,12 +29,12 @@ public class SimulationAgentMessenger {
      * @param simulationAgent simulation agent to which message will be sent
      * @return prepared message
      * @throws Codec.CodecException language fipa-sl0 is not registered
-     * @throws OntologyException weather ontology is not registered
+     * @throws OntologyException room climate ontology is not registered
      */
     public static ACLMessage prepareInfoRequest(int roomId, Agent myAgent, AID simulationAgent)
             throws Codec.CodecException, OntologyException {
         InfoRequest request = new InfoRequest(roomId);
-        return createActionMessage(myAgent, simulationAgent, request, WeatherOntology.getInstance());
+        return createActionMessage(myAgent, simulationAgent, request, RoomClimateOntology.getInstance());
     }
 
 
@@ -48,7 +45,7 @@ public class SimulationAgentMessenger {
      * @param msg message with room climate
      * @return extracted room climate if message contains one
      * @throws Codec.CodecException language fipa-sl0 is not registered or message received is not in this language
-     * @throws OntologyException weather ontology is not registered or message received is not in this ontology
+     * @throws OntologyException room climate ontology is not registered or message received is not in this ontology
      */
     public static Optional<RoomClimate> extractRoomClimate(Agent myAgent, ACLMessage msg)
             throws Codec.CodecException, OntologyException {
@@ -67,7 +64,7 @@ public class SimulationAgentMessenger {
      * @param simulationAgent simulation agent to which message will be sent
      * @return prepared message
      * @throws Codec.CodecException language fipa-sl0 is not registered
-     * @throws OntologyException weather ontology is not registered
+     * @throws OntologyException machinery ontology is not registered
      */
     public static ACLMessage prepareReportMachineryStatus(int roomId, Agent myAgent, AID simulationAgent)
             throws Codec.CodecException, OntologyException {
@@ -83,13 +80,13 @@ public class SimulationAgentMessenger {
      * @param msg message with room climate
      * @return extracted machinery status if message contains one
      * @throws Codec.CodecException language fipa-sl0 is not registered or message received is not in this language
-     * @throws OntologyException weather ontology is not registered or message received is not in this ontology
+     * @throws OntologyException machinery ontology is not registered or message received is not in this ontology
      */
-    public static Optional<RoomClimate> extractMachineryStatus(Agent myAgent, ACLMessage msg)
+    public static Optional<MachineryStatus> extractMachineryStatus(Agent myAgent, ACLMessage msg)
             throws Codec.CodecException, OntologyException {
         ContentElement content = myAgent.getContentManager().extractContent(msg);
-        if(content instanceof RoomClimate) {
-            return Optional.of((RoomClimate)content);
+        if(content instanceof MachineryStatus) {
+            return Optional.of((MachineryStatus)content);
         }
         return Optional.empty();
     }
@@ -102,7 +99,7 @@ public class SimulationAgentMessenger {
      * @param simulationAgent simulation agent to which message will be sent
      * @return prepared message
      * @throws Codec.CodecException language fipa-sl0 is not registered
-     * @throws OntologyException weather ontology is not registered
+     * @throws OntologyException machinery ontology is not registered
      */
     public static ACLMessage prepareUpdateMachinery(Machinery machinery, int roomId, Agent myAgent, AID simulationAgent)
             throws Codec.CodecException, OntologyException {

--- a/src/main/java/hvac/simulation/SimulationContext.java
+++ b/src/main/java/hvac/simulation/SimulationContext.java
@@ -2,6 +2,7 @@ package hvac.simulation;
 
 import hvac.simulation.rooms.RoomClimate;
 import hvac.simulation.rooms.RoomMap;
+import hvac.util.Logger;
 
 import java.util.Hashtable;
 
@@ -9,6 +10,7 @@ public class SimulationContext {
     private final RoomMap roomMap = new RoomMap();
     private final Hashtable<Integer, RoomClimate> climates = new Hashtable<>();
     private final OutsideClimate outsideClimate = new OutsideClimate();
+    private final Logger logger = new Logger();
 
     public RoomMap getRoomMap() {
         return roomMap;
@@ -20,5 +22,9 @@ public class SimulationContext {
 
     public OutsideClimate getOutsideClimate() {
         return outsideClimate;
+    }
+
+    public Logger getLogger() {
+        return logger;
     }
 }

--- a/src/main/java/hvac/simulation/behaviours/ClimateInformingBehaviour.java
+++ b/src/main/java/hvac/simulation/behaviours/ClimateInformingBehaviour.java
@@ -63,6 +63,8 @@ public class ClimateInformingBehaviour extends CyclicBehaviour {
                     ACLMessage reply = msg.createReply();
                     reply.setPerformative(ACLMessage.INFORM);
                     myAgent.getContentManager().fillContent(reply, roomClimate);
+                    context.getLogger().log("replying to climate request: roomId: " + infoRequest.getRoomId() +
+                            ", temperature: " + roomClimate.getTemperature());
                     myAgent.send(reply);
                 } else {
                     replyRefuse(msg);

--- a/src/main/java/hvac/simulation/behaviours/ClimateInformingBehaviour.java
+++ b/src/main/java/hvac/simulation/behaviours/ClimateInformingBehaviour.java
@@ -64,7 +64,8 @@ public class ClimateInformingBehaviour extends CyclicBehaviour {
                     reply.setPerformative(ACLMessage.INFORM);
                     myAgent.getContentManager().fillContent(reply, roomClimate);
                     context.getLogger().log("replying to climate request: roomId: " + infoRequest.getRoomId() +
-                            ", temperature: " + roomClimate.getTemperature());
+                            ", temperature: " + roomClimate.getTemperature() +
+                            ", relative humidity: " + roomClimate.getRelativeHumidity());
                     myAgent.send(reply);
                 } else {
                     replyRefuse(msg);

--- a/src/main/java/hvac/simulation/behaviours/ClimateUpdatingBehaviour.java
+++ b/src/main/java/hvac/simulation/behaviours/ClimateUpdatingBehaviour.java
@@ -165,7 +165,7 @@ public class ClimateUpdatingBehaviour extends TickerBehaviour {
         float saturationWaterVapour = (float)(pressureFunctionValue * 6.112
                 * Math.exp(17.62*tempCelsius/(243.12+tempCelsius)));
         float currentWaterVapour = newClimate.getAbsoluteHumidity() * 461.5f * newClimate.getTemperature();
-        return currentWaterVapour/saturationWaterVapour;
+        return currentWaterVapour/saturationWaterVapour*0.01f;
     }
 
     private float calculateAirQualityFor(Room r, RoomClimate oldClimate) {

--- a/src/main/java/hvac/time/DateTimeSimulator.java
+++ b/src/main/java/hvac/time/DateTimeSimulator.java
@@ -20,4 +20,8 @@ public class DateTimeSimulator {
         double diff = (double)(realCurrentDate - realStartDate) * timeScale * 0.001f;
         return startDate.plusSeconds((long)diff);
     }
+
+    public static float getTimeScale() {
+        return timeScale;
+    }
 }

--- a/src/main/java/hvac/util/Conversions.java
+++ b/src/main/java/hvac/util/Conversions.java
@@ -6,7 +6,10 @@ import hvac.simulation.rooms.RoomClimate;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class Conversions {
     public static LocalDateTime toLocalDateTime(Date date) {
@@ -37,5 +40,14 @@ public class Conversions {
 
     public static hvac.ontologies.machinery.MachineParameter toOntologyParameter(hvac.simulation.machinery.MachineParameter parameter) {
         return new MachineParameter(parameter.getCurrentValue(), parameter.getMaxValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> toJavaList(jade.util.leap.List jadeList) {
+        try {
+            return Arrays.stream(jadeList.toArray()).map(it->(T)it).collect(Collectors.toList());
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("elements of given jade list are not of type required for result list");
+        }
     }
 }

--- a/src/main/java/hvac/util/Helpers.java
+++ b/src/main/java/hvac/util/Helpers.java
@@ -1,9 +1,65 @@
 package hvac.util;
 
+import hvac.ontologies.machinery.Machinery;
+import hvac.time.DateTimeSimulator;
+import jade.core.Agent;
+
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 public class Helpers {
     public static boolean isBetween(LocalDateTime date, LocalDateTime start, LocalDateTime end) {
         return date.isAfter(start) && date.isBefore(end);
+    }
+
+    public static boolean initTimeFromArgs(Agent agent, Consumer<String> usageFunction) {
+        Object[] arguments = agent.getArguments();
+        if (arguments == null || arguments.length < 2) {
+            usageFunction.accept("Wrong args num");
+            agent.doDelete();
+            return false;
+        }
+        LocalDateTime startTime;
+        float timeScale;
+        try {
+            timeScale = Float.parseFloat(arguments[0].toString());
+            startTime = LocalDateTime.parse(arguments[1].toString(),
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        } catch (NumberFormatException | DateTimeParseException e) {
+            usageFunction.accept(e.getMessage());
+            agent.doDelete();
+            return false;
+        }
+        DateTimeSimulator.init(startTime, timeScale);
+        return true;
+    }
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public static boolean almostEqual(float f1, float f2, float epsilon) {
+        return Math.abs(f1-f2)<epsilon;
+    }
+    public static void updateMachinery(Machinery updatedMachinery, Machinery updatingMachinery) {
+        Optional.ofNullable(updatingMachinery.getAirConditioner()).ifPresent(airConditioner -> {
+            Optional.ofNullable(airConditioner.getCoolingPower())
+                    .ifPresent(coolingPower ->
+                            updatedMachinery.getAirConditioner().getCoolingPower()
+                                    .setCurrentValue(coolingPower.getCurrentValue()));
+            Optional.ofNullable(airConditioner.getAirExchangedPerSecond())
+                    .ifPresent(airExchangedPerSecond ->
+                            updatedMachinery.getAirConditioner().getAirExchangedPerSecond()
+                                    .setCurrentValue(airExchangedPerSecond.getCurrentValue()));
+        });
+        Optional.ofNullable(updatingMachinery.getHeater())
+                .flatMap(heater -> Optional.ofNullable(heater.getHeatingPower()))
+                .ifPresent(heatingPower ->
+                        updatedMachinery.getHeater().getHeatingPower()
+                                .setCurrentValue(heatingPower.getCurrentValue()));
+        Optional.ofNullable(updatingMachinery.getVentilator())
+                .flatMap(ventilator -> Optional.ofNullable(ventilator.getAirExchangedPerSecond()))
+                .ifPresent(airExchangedPerSecond ->
+                        updatedMachinery.getVentilator().getAirExchangedPerSecond()
+                                .setCurrentValue(airExchangedPerSecond.getCurrentValue()));
     }
 }

--- a/src/main/java/hvac/util/Interpolation.java
+++ b/src/main/java/hvac/util/Interpolation.java
@@ -1,0 +1,17 @@
+package hvac.util;
+
+import org.apache.commons.math3.analysis.interpolation.SplineInterpolator;
+
+import java.util.List;
+
+
+public class Interpolation {
+    public static float calculateValueAt(float x, List<Float> knownX, List<Float> knownY) {
+        if(knownX.size() != knownY.size()) {
+            throw new IllegalArgumentException("input lists must be of the same length");
+        }
+        double[] xArray = knownX.stream().mapToDouble(Float::doubleValue).toArray();
+        double[] yArray = knownY.stream().mapToDouble(Float::doubleValue).toArray();
+        return (float) new SplineInterpolator().interpolate(xArray,yArray).value(x);
+    }
+}

--- a/src/main/java/hvac/util/Logger.java
+++ b/src/main/java/hvac/util/Logger.java
@@ -1,0 +1,23 @@
+package hvac.util;
+
+import hvac.time.DateTimeSimulator;
+
+import java.time.format.DateTimeFormatter;
+
+public class Logger {
+    private String agentName = "unnamed agent";
+    private DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    public void log(String msg) {
+        System.out.println("[" + DateTimeSimulator.getCurrentDate().format(formatter) + "]"
+        + agentName + ": " + msg);
+    }
+
+    public String getAgentName() {
+        return agentName;
+    }
+
+    public void setAgentName(String agentName) {
+        this.agentName = agentName;
+    }
+}

--- a/src/main/java/hvac/weatherforecaster/WeatherForecasterMessenger.java
+++ b/src/main/java/hvac/weatherforecaster/WeatherForecasterMessenger.java
@@ -3,6 +3,7 @@ package hvac.weatherforecaster;
 import hvac.ontologies.weather.Forecast;
 import hvac.ontologies.weather.ForecastRequest;
 import hvac.ontologies.weather.WeatherOntology;
+import hvac.util.Conversions;
 import jade.content.ContentElement;
 import jade.content.lang.Codec;
 import jade.content.onto.OntologyException;
@@ -12,6 +13,7 @@ import jade.core.Agent;
 import jade.domain.FIPANames;
 import jade.lang.acl.ACLMessage;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -21,20 +23,24 @@ public class WeatherForecasterMessenger {
     /**
      * prepares message that when sent to Weather forecaster will result in correct snapshot
      * Requires that agent has registered sl0 language and weather ontology
-     * @param request request to send to forecaster
+     * @param from oldest date that provided forecast can have
+     * @param to newest date that provided forecasts can have
      * @param myAgent agent that will send the message
      * @param forecaster forecaster to which message will be sent
      * @return prepared message
      * @throws Codec.CodecException
      * @throws OntologyException
      */
-    public static ACLMessage prepareForecastRequest(ForecastRequest request, Agent myAgent, AID forecaster)
+    public static ACLMessage prepareForecastRequest(LocalDateTime from, LocalDateTime to, Agent myAgent, AID forecaster)
             throws Codec.CodecException, OntologyException {
         ACLMessage msg = new ACLMessage(ACLMessage.REQUEST);
         msg.addReceiver(forecaster);
         msg.setLanguage(FIPANames.ContentLanguage.FIPA_SL0);
         msg.setOntology(WeatherOntology.getInstance().getName());
-        Action action = new Action(forecaster, request);
+        Action action = new Action(forecaster, new ForecastRequest(
+                Conversions.toDate(from),
+                Conversions.toDate(to)
+        ));
         myAgent.getContentManager().fillContent(msg, action);
         return msg;
     }


### PR DESCRIPTION
upkeeper utrzymuje warunki związane z nadchodzącym spotkaniem, w swoim pokoju. Nie przechodzi natychmiastowo do tych warunków, tylko ustala jaka musi być zmiana ich w czasie i na podstawie tego interpoluje jakie parametry maszynerii trzeba ustawić. Na razie następne spotkanie jest sztywno zaszyte w kodzie, trzeba dodać zachowanie odbierające następne spotkanie/jakiś inny sposób informowania przez room coordinatora jakie warunki upkeeper ma zachowywać. Pewnie też przydałoby się przerobić wszystkich agentów aby korzystali z directory facilitatora, bo na razie jest przesyłanie tylko po nazwach agentów.
Można testować z takimi parametrami uruchomienia:
-gui -agents forecaster:hvac.weatherforecaster.WeatherForecasterAgent(20,"2015-05-20 10:20:00");simulation:hvac.simulation.SimulationAgent(20,"2015-05-20 10:20:00");roomUpkeeper:hvac.roomupkeeper.RoomUpkeeperAgent(20,"2015-05-20 10:20:00",1,50)