### PR TITLE
Using directory facilitator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Click the + button and choose application.
 Select jade.Boot as the main class and specify arguments, for example:
 -gui -agents a:HelloWorldAgent
 
-You can name this configuration apropriately.
+You can name this configuration appropriately.
 
 Press ok and run.
 
@@ -33,7 +33,7 @@ This will also delete previous weather data.
 
 ### Google Calendar
 To use this project you need to register it with google calendar.
-To do it place provided StoredCredential file in the same location as StoredCredential.hehe file
+To do it place provided StoredCredential file in the same location as StoredCredential.here file
 or generate credentials for your google account [here](https://developers.google.com/calendar/quickstart/java)
 (click Enable the google calendar API button) and place generated file in the same location as
 credentials.json.here file. As StoredCredentials and credentials.json files contain sensitive data

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
             <artifactId>google-api-services-calendar</artifactId>
             <version>v3-rev305-1.23.0</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-math3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
     </dependencies>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/hvac/coordinator/CoordinatorAgent.java
+++ b/src/main/java/hvac/coordinator/CoordinatorAgent.java
@@ -5,6 +5,7 @@ import hvac.calendar.CalendarException;
 import hvac.calendar.CalendarWrapper;
 import hvac.coordinator.behaviours.MeetingUpdatingBehaviour;
 import hvac.database.Connection;
+import hvac.util.df.DfHelpers;
 import jade.core.Agent;
 
 import static hvac.util.Helpers.initTimeFromArgs;
@@ -17,6 +18,7 @@ public class CoordinatorAgent extends Agent {
     @Override
     protected void setup() {
         if(!initTimeFromArgs(this, this::usage)) return;
+        if(!DfHelpers.tryRegisterInDfWithServiceName(this, "coordinator")) return;
         database = new Connection();
         CalendarWrapper wrapper = new CalendarWrapper();
         try {

--- a/src/main/java/hvac/coordinator/CoordinatorAgent.java
+++ b/src/main/java/hvac/coordinator/CoordinatorAgent.java
@@ -5,12 +5,9 @@ import hvac.calendar.CalendarException;
 import hvac.calendar.CalendarWrapper;
 import hvac.coordinator.behaviours.MeetingUpdatingBehaviour;
 import hvac.database.Connection;
-import hvac.time.DateTimeSimulator;
 import jade.core.Agent;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
+import static hvac.util.Helpers.initTimeFromArgs;
 
 @SuppressWarnings("unused")
 public class CoordinatorAgent extends Agent {
@@ -19,7 +16,7 @@ public class CoordinatorAgent extends Agent {
     CoordinatorContext context = new CoordinatorContext();
     @Override
     protected void setup() {
-        initTimeFromArgs();
+        if(!initTimeFromArgs(this, this::usage)) return;
         database = new Connection();
         CalendarWrapper wrapper = new CalendarWrapper();
         try {
@@ -31,26 +28,6 @@ public class CoordinatorAgent extends Agent {
             return;
         }
         this.addBehaviour(new MeetingUpdatingBehaviour(this, 1000, calendar, context));
-    }
-
-    private void initTimeFromArgs() {
-        if (getArguments() == null || getArguments().length != 2) {
-            usage("Wrong args num");
-            doDelete();
-            return;
-        }
-        LocalDateTime startTime;
-        float timeScale;
-        try {
-            timeScale = Float.parseFloat(getArguments()[0].toString());
-            startTime = LocalDateTime.parse(getArguments()[1].toString(),
-                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        } catch (NumberFormatException | DateTimeParseException e) {
-            usage(e.getMessage());
-            doDelete();
-            return;
-        }
-        DateTimeSimulator.init(startTime, timeScale);
     }
 
     private void usage(String err) {

--- a/src/main/java/hvac/roomcoordinator/RoomContext.java
+++ b/src/main/java/hvac/roomcoordinator/RoomContext.java
@@ -8,30 +8,41 @@ import java.util.*;
 
 public class RoomContext {
     private static final float defaultTemperature = 21;
-    private AID coordinator;
+    private final int myRoomId;
+    private final AID coordinator;
     private AID myRoomUpkeeper;
-    private HashMap<AID, RoomWall> myNeighbours;
+    private final HashMap<AID, RoomWall> myNeighbours = new HashMap<>();
     private Meeting currentMeeting;
-    private PriorityQueue<Meeting> meetingsQueue = new PriorityQueue<>();
-    private Map<String, AbstractMap.SimpleEntry<Meeting, Map<AID, Float>>> neighboursForecastStatus = new HashMap<>();
+    private final PriorityQueue<Meeting> meetingsQueue = new PriorityQueue<>();
+    private final Map<String, AbstractMap.SimpleEntry<Meeting, Map<AID, Float>>> neighboursForecastStatus = new HashMap<>();
 
-    RoomContext(AID myRoomUpkeeper, AID coordinator, HashMap<AID, RoomWall>  myNeighbours){
+    RoomContext(int myRoomId, AID coordinator){
+        this.myRoomId = myRoomId;
         this.coordinator = coordinator;
-        this.myRoomUpkeeper = myRoomUpkeeper;
-        this.myNeighbours = myNeighbours;
+    }
+
+    public int getMyRoomId() {
+        return myRoomId;
     }
 
     public AID getCoordinator() {
         return coordinator;
     }
 
-    @SuppressWarnings("unused")
     public AID getMyRoomUpkeeper() {
         return myRoomUpkeeper;
     }
 
+    public void setMyRoomUpkeeper(AID myRoomUpkeeper){
+        this.myRoomUpkeeper = myRoomUpkeeper;
+    }
+
     public HashMap<AID, RoomWall>  getMyNeighbours() {
         return myNeighbours;
+    }
+
+    public void addMyNeighbour(AID key, RoomWall value){
+        myNeighbours.put(key, value);
     }
 
     public Meeting getCurrentMeeting() {

--- a/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
+++ b/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
@@ -1,247 +1,78 @@
 package hvac.roomcoordinator;
 
-import hvac.ontologies.meeting.Meeting;
 import hvac.ontologies.meeting.MeetingOntology;
-import hvac.ontologies.meeting.Request;
-import hvac.ontologies.meeting.RequestStatus;
+import hvac.roomcoordinator.behaviours.RoomCoordinatorCyclicBehaviour;
+import hvac.roomcoordinator.behaviours.RoomCoordinatorTickerBehaviour;
 import hvac.simulation.rooms.RoomWall;
-import jade.content.lang.Codec;
+import hvac.util.df.DfHelpers;
+import hvac.util.df.FindingBehaviour;
 import jade.content.lang.sl.SLCodec;
-import jade.content.onto.Ontology;
 import jade.core.AID;
 import jade.core.Agent;
-import jade.core.behaviours.CyclicBehaviour;
-import jade.core.behaviours.TickerBehaviour;
-import jade.lang.acl.ACLMessage;
-
-import java.util.Date;
-import java.util.HashMap;
 
 @SuppressWarnings("unused")
 public class RoomCoordinatorAgent extends Agent {
     private RoomContext roomContext;
-    private TickerBehaviour tickerBehaviour;
-    private static Codec codec = new SLCodec();
-    private static Ontology meetingOntology = MeetingOntology.getInstance();
+    private Integer[] Ids;
+    private RoomWall[] RoomWalls;
+    private int roomsProcessed = 0;
 
     @Override
     protected void setup() {
-        getContentManager().registerLanguage(codec);
-        getContentManager().registerOntology(meetingOntology);
-        Object[] args =  getArguments();
-        HashMap<AID, RoomWall> roomConfig = null;
-        //checking if map was passed correctly, unfortunately this is IMO the best and proper way
-        // to detect and avoid errors and warnings
+        getContentManager().registerLanguage(new SLCodec());
+        getContentManager().registerOntology(MeetingOntology.getInstance());
+        roomContext = getContext();
+        if(roomContext == null) {
+            doDelete();
+        }
+    }
+
+    private RoomContext getContext() {
+        int myRoomId;
         try {
-            @SuppressWarnings("unchecked")
-            HashMap<AID, RoomWall> hashMap = (HashMap<AID, RoomWall>) args[2];
-            hashMap.keySet().forEach(x -> {});
-            hashMap.values().forEach(x -> {});
-            roomConfig = hashMap;
-        }
-        catch (ClassCastException e) {e.printStackTrace();doDelete();}
-        roomContext = new RoomContext(
-                (AID) args[0],
-                (AID) args[1],
-                roomConfig
-        );
-        tickerBehaviour = new TickerBehaviour(this, 1000) {
-
-            @Override
-            protected void onTick() {
-                if (null == roomContext.getCurrentMeeting()){
-                    Meeting meeting = roomContext.checkMeetings(new Date());
-                    if (null != meeting){
-                        roomContext.setCurrentMeeting(meeting);
-                        ACLMessage msg = new ACLMessage(ACLMessage.INFORM);
-                        Request request = new Request(roomContext.getCurrentMeeting(), RequestStatus.EXECUTE);
-                        sendUpdateToUpkeeper(msg, request);
-                        this.reset(meeting.getEndDate().getTime() - new Date().getTime());
-                    }
-                    else{
-                        if (null != roomContext.peekMeeting()){
-                            this.reset(roomContext.peekMeeting().getStartDate().getTime() - new Date().getTime());
-                        }
-                        else{
-                            this.reset(Long.MAX_VALUE);
-                        }
-                    }
-                }
-                else{
-                    if (roomContext.getCurrentMeeting().getEndDate().before(new Date())){
-                        Meeting currentMeeting = roomContext.getCurrentMeeting();
-                        ACLMessage msg = new ACLMessage(ACLMessage.INFORM);
-                        Request request = new Request(currentMeeting, RequestStatus.FINISHED);
-                        sendUpdateToUpkeeper(msg, request);
-                        roomContext.setCurrentMeeting(null);
-                        roomContext.removeMeeting(currentMeeting.getMeetingID());
-                        this.reset(0);
-                    }
-                    else{
-                        this.reset(1000);
-                    }
-                }
-            }
-        };
-        addBehaviour(tickerBehaviour);
-        addBehaviour(new CyclicBehaviour() {
-            @Override
-            public void action() {
-                ACLMessage msg = myAgent.receive();
-                if (msg != null) {
-                    handleMessage(msg);
-                }
-                else {
-                    block();
-                }
-            }
-        });
-    }
-
-    private void handleMessage(ACLMessage msg){
-        switch(msg.getPerformative()) {
-            case ACLMessage.CFP:
-                handleCFP(msg);
-                break;
-            case ACLMessage.REQUEST:
-                handleRequest(msg);
-                break;
-            case ACLMessage.INFORM:
-                handleInform(msg);
-                break;
-            case ACLMessage.ACCEPT_PROPOSAL:
-                handleAcceptProposal(msg);
-                break;
-            case ACLMessage.CANCEL:
-                handleCancel(msg);
-                break;
-            case ACLMessage.REJECT_PROPOSAL:
-            case ACLMessage.NOT_UNDERSTOOD:
-                break;
-            default:
-                notUnderstood(msg);
-        }
-    }
-
-    private void handleCFP(ACLMessage msg){
-        Request request = extractRequest(msg);
-        if (null == request){
-            return;
-        }
-        if (! roomContext.isTimeSlotAvailable(request.getMeeting())){
-            ACLMessage reply = msg.createReply();
-            reply.setPerformative(ACLMessage.REFUSE);
-            request.setStatus(RequestStatus.FAILED);
-            fillAndSend(reply, request);
-            return;
-        }
-        ACLMessage requestForecast = msg.createReply();
-        requestForecast.clearAllReceiver();
-        for (AID neighbour:roomContext.getMyNeighbours().keySet()){
-            requestForecast.addReceiver(neighbour);
-        }
-        request.setStatus(RequestStatus.FORECAST);
-        fillAndSend(requestForecast,request);
-        roomContext.newForecastEntry(request.getMeeting());
-    }
-
-    private void handleRequest(ACLMessage msg){
-        Request request = extractRequest(msg);
-        if (null == request){
-            return;
-        }
-        request.getMeeting().setTemperature(roomContext.estimateTemperatureForNeighbour(request.getMeeting()));
-        ACLMessage reply = msg.createReply();
-        reply.setPerformative(ACLMessage.INFORM);
-        request.setStatus(RequestStatus.ESTIMATION);
-        fillAndSend(reply, request);
-    }
-
-    private void handleInform(ACLMessage msg){
-        Request request = extractRequest(msg);
-        if (null == request){
-            return;
-        }
-        roomContext.addNeighbourForecast(
-                request.getMeeting().getMeetingID(),
-                msg.getSender(),
-                request.getMeeting().getTemperature());
-        if (! roomContext.isForecastCompleted(request.getMeeting().getMeetingID())){
-            return;
-        }
-        request.getMeeting().setTemperature(roomContext.computeForecast(request.getMeeting().getMeetingID()));
-        roomContext.removeForecastEntry(request.getMeeting().getMeetingID());
-        ACLMessage reply = msg.createReply();
-        msg.setPerformative(ACLMessage.PROPOSE);
-        msg.clearAllReceiver();
-        msg.addReceiver(roomContext.getCoordinator());
-        request.setStatus(RequestStatus.OFFER);
-        fillAndSend(reply, request);
-    }
-
-    private void handleAcceptProposal(ACLMessage msg){
-        Request request = extractRequest(msg);
-        if (null == request) {
-            return;
-        }
-        ACLMessage reply = msg.createReply();
-        if (roomContext.isTimeSlotAvailable(request.getMeeting())){
-            reply.setPerformative(ACLMessage.INFORM);
-            request.setStatus(RequestStatus.RESERVED);
-            roomContext.addMeeting(request.getMeeting());
-        }
-        else {
-            reply.setPerformative(ACLMessage.REFUSE);
-            request.setStatus(RequestStatus.FAILED);
-        }
-        fillAndSend(reply, request);
-        tickerBehaviour.reset(0);
-    }
-
-    private void handleCancel(ACLMessage msg){
-        Request request = extractRequest(msg);
-        if (null == request){
-            return;
-        }
-        roomContext.removeMeeting(request.getMeeting().getMeetingID());
-        ACLMessage reply = msg.createReply();
-        reply.setPerformative(ACLMessage.CONFIRM);
-        request.setStatus(RequestStatus.CANCELLED);
-        fillAndSend(reply, request);
-        tickerBehaviour.reset(0);
-    }
-
-    private void notUnderstood(ACLMessage msg){
-        ACLMessage reply = msg.createReply();
-        reply.setPerformative(ACLMessage.NOT_UNDERSTOOD);
-        reply.setContent(msg.getContent());
-        send(reply);
-    }
-
-    private Request extractRequest(ACLMessage msg){
-        Request request = null;
-        try {
-            request = (Request) getContentManager().extractContent(msg);
-        } catch (Exception e){e.printStackTrace();}
-        if (null == request || null == request.getMeeting()){
-            notUnderstood(msg);
+            myRoomId = Integer.parseInt(getArguments()[0].toString());
+        } catch (NumberFormatException e) {
+            usage("room Id is not valid");
             return null;
         }
-        return request;
+        if(!DfHelpers.tryRegisterInDfWithServiceName(this, "room-coordinator-" + myRoomId)) {
+            usage("room cannot be registered in DF");
+            return null;
+        }
+        RoomContext newRoomContext = new RoomContext(myRoomId, (AID) getArguments()[1]);
+        Ids = (Integer[]) getArguments()[2];
+        RoomWalls = (RoomWall[]) getArguments()[3];
+
+        addBehaviour(new FindingBehaviour(this, "upkeeper-" + myRoomId,
+                upkeeperDescriptor->{
+                    newRoomContext.setMyRoomUpkeeper(upkeeperDescriptor.getName());
+                    processRoom();}));
+
+        return newRoomContext;
     }
 
-    private void fillAndSend(ACLMessage msg, Request request){
-        try {
-            getContentManager().fillContent(msg, request);
-        } catch (Exception e){e.printStackTrace();}
-        send(msg);
+    private void processRoom(){
+        if (Ids.length == roomsProcessed) {
+            RoomCoordinatorTickerBehaviour tickerBehaviour = new RoomCoordinatorTickerBehaviour(this, 1000, roomContext);
+            addBehaviour(tickerBehaviour);
+            addBehaviour(new RoomCoordinatorCyclicBehaviour(this, roomContext, tickerBehaviour));
+            return;
+        }
+        addBehaviour(new FindingBehaviour(this, "room-coordinator-" + Ids[roomsProcessed],
+                neighbourDescriptor->{
+                    roomContext.addMyNeighbour(neighbourDescriptor.getName(),RoomWalls[roomsProcessed]);
+                    roomsProcessed++;
+                    processRoom();}));
     }
 
-    private void sendUpdateToUpkeeper(ACLMessage msg, Request request){
-        msg.setConversationId(roomContext.getCurrentMeeting().getMeetingID());
-        msg.setLanguage(codec.getName());
-        msg.setOntology(meetingOntology.getName());
-        msg.addReceiver(roomContext.getMyRoomUpkeeper());
-        fillAndSend(msg, request);
+
+    private void usage(String err) {
+        System.err.println("-------- Room Coordinator agent usage --------------");
+        System.err.println("simulation:hvac.roomcoordinator.RoomCoordinatorAgent(RoomId, CoordinatorAID, NeighboursIds, RoomWalls)");
+        System.err.println("RoomId - integer uniquely identifying the room of this agent");
+        System.err.println("CoordinatorAID - AID of Coordinator");
+        System.err.println("NeighboursIds - array of neighbours' Ids");
+        System.err.println("RoomWalls - array of walls' properties");
+        System.err.println("err:" + err);
     }
 }

--- a/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorCyclicBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorCyclicBehaviour.java
@@ -1,0 +1,170 @@
+package hvac.roomcoordinator.behaviours;
+
+import hvac.ontologies.meeting.Request;
+import hvac.ontologies.meeting.RequestStatus;
+import hvac.roomcoordinator.RoomContext;
+import jade.core.AID;
+import jade.core.Agent;
+import jade.core.behaviours.CyclicBehaviour;
+import jade.lang.acl.ACLMessage;
+
+public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
+    private final RoomContext roomContext;
+    private final RoomCoordinatorTickerBehaviour tickerBehaviour;
+
+    public RoomCoordinatorCyclicBehaviour(Agent a, RoomContext roomContext, RoomCoordinatorTickerBehaviour tickerBehaviour) {
+        super(a);
+        this.roomContext = roomContext;
+        this.tickerBehaviour = tickerBehaviour;
+    }
+
+    @Override
+    public void action() {
+        ACLMessage msg = myAgent.receive();
+        if (msg != null) {
+            handleMessage(msg);
+        }
+        else {
+            block();
+        }
+    }
+
+    private void handleMessage(ACLMessage msg){
+        switch(msg.getPerformative()) {
+            case ACLMessage.CFP:
+                handleCFP(msg);
+                break;
+            case ACLMessage.REQUEST:
+                handleRequest(msg);
+                break;
+            case ACLMessage.INFORM:
+                handleInform(msg);
+                break;
+            case ACLMessage.ACCEPT_PROPOSAL:
+                handleAcceptProposal(msg);
+                break;
+            case ACLMessage.CANCEL:
+                handleCancel(msg);
+                break;
+            case ACLMessage.REJECT_PROPOSAL:
+            case ACLMessage.NOT_UNDERSTOOD:
+                break;
+            default:
+                notUnderstood(msg);
+        }
+    }
+
+    private void handleCFP(ACLMessage msg){
+        Request request = extractRequest(msg);
+        if (null == request){
+            return;
+        }
+        if (! roomContext.isTimeSlotAvailable(request.getMeeting())){
+            ACLMessage reply = msg.createReply();
+            reply.setPerformative(ACLMessage.REFUSE);
+            request.setStatus(RequestStatus.FAILED);
+            fillAndSend(reply, request);
+            return;
+        }
+        ACLMessage requestForecast = msg.createReply();
+        requestForecast.clearAllReceiver();
+        for (AID neighbour:roomContext.getMyNeighbours().keySet()){
+            requestForecast.addReceiver(neighbour);
+        }
+        request.setStatus(RequestStatus.FORECAST);
+        fillAndSend(requestForecast,request);
+        roomContext.newForecastEntry(request.getMeeting());
+    }
+
+    private void handleRequest(ACLMessage msg){
+        Request request = extractRequest(msg);
+        if (null == request){
+            return;
+        }
+        request.getMeeting().setTemperature(roomContext.estimateTemperatureForNeighbour(request.getMeeting()));
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.INFORM);
+        request.setStatus(RequestStatus.ESTIMATION);
+        fillAndSend(reply, request);
+    }
+
+    private void handleInform(ACLMessage msg){
+        Request request = extractRequest(msg);
+        if (null == request){
+            return;
+        }
+        roomContext.addNeighbourForecast(
+                request.getMeeting().getMeetingID(),
+                msg.getSender(),
+                request.getMeeting().getTemperature());
+        if (! roomContext.isForecastCompleted(request.getMeeting().getMeetingID())){
+            return;
+        }
+        request.getMeeting().setTemperature(roomContext.computeForecast(request.getMeeting().getMeetingID()));
+        roomContext.removeForecastEntry(request.getMeeting().getMeetingID());
+        ACLMessage reply = msg.createReply();
+        msg.setPerformative(ACLMessage.PROPOSE);
+        msg.clearAllReceiver();
+        msg.addReceiver(roomContext.getCoordinator());
+        request.setStatus(RequestStatus.OFFER);
+        fillAndSend(reply, request);
+    }
+
+    private void handleAcceptProposal(ACLMessage msg){
+        Request request = extractRequest(msg);
+        if (null == request) {
+            return;
+        }
+        ACLMessage reply = msg.createReply();
+        if (roomContext.isTimeSlotAvailable(request.getMeeting())){
+            reply.setPerformative(ACLMessage.INFORM);
+            request.setStatus(RequestStatus.RESERVED);
+            roomContext.addMeeting(request.getMeeting());
+        }
+        else {
+            reply.setPerformative(ACLMessage.REFUSE);
+            request.setStatus(RequestStatus.FAILED);
+        }
+        fillAndSend(reply, request);
+        tickerBehaviour.reset(0);
+    }
+
+    private void handleCancel(ACLMessage msg){
+        Request request = extractRequest(msg);
+        if (null == request){
+            return;
+        }
+        roomContext.removeMeeting(request.getMeeting().getMeetingID());
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.CONFIRM);
+        request.setStatus(RequestStatus.CANCELLED);
+        fillAndSend(reply, request);
+        tickerBehaviour.reset(0);
+    }
+
+    private void notUnderstood(ACLMessage msg){
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.NOT_UNDERSTOOD);
+        reply.setContent(msg.getContent());
+        myAgent.send(reply);
+    }
+
+    private Request extractRequest(ACLMessage msg){
+        Request request = null;
+        try {
+            request = (Request) myAgent.getContentManager().extractContent(msg);
+        } catch (Exception e){e.printStackTrace();}
+        if (null == request || null == request.getMeeting()){
+            notUnderstood(msg);
+            return null;
+        }
+        return request;
+    }
+
+    private void fillAndSend(ACLMessage msg, Request request){
+        try {
+            myAgent.getContentManager().fillContent(msg, request);
+        } catch (Exception e){e.printStackTrace();}
+        myAgent.send(msg);
+    }
+}

--- a/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorTickerBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorTickerBehaviour.java
@@ -1,0 +1,73 @@
+package hvac.roomcoordinator.behaviours;
+
+import hvac.ontologies.meeting.Meeting;
+import hvac.ontologies.meeting.MeetingOntology;
+import hvac.ontologies.meeting.Request;
+import hvac.ontologies.meeting.RequestStatus;
+import hvac.roomcoordinator.RoomContext;
+import jade.content.lang.sl.SLCodec;
+import jade.core.Agent;
+import jade.core.behaviours.TickerBehaviour;
+import jade.lang.acl.ACLMessage;
+
+import java.util.Date;
+
+public class RoomCoordinatorTickerBehaviour extends TickerBehaviour {
+    private final RoomContext roomContext;
+
+    public RoomCoordinatorTickerBehaviour(Agent a, long period, RoomContext roomContext) {
+        super(a, period);
+        this.roomContext = roomContext;
+    }
+
+    @Override
+    protected void onTick() {
+        if (null == roomContext.getCurrentMeeting()){
+            Meeting meeting = roomContext.checkMeetings(new Date());
+            if (null != meeting){
+                roomContext.setCurrentMeeting(meeting);
+                ACLMessage msg = new ACLMessage(ACLMessage.INFORM);
+                Request request = new Request(roomContext.getCurrentMeeting(), RequestStatus.EXECUTE);
+                sendUpdateToUpkeeper(msg, request);
+                this.reset(meeting.getEndDate().getTime() - new Date().getTime());
+            }
+            else{
+                if (null != roomContext.peekMeeting()){
+                    this.reset(roomContext.peekMeeting().getStartDate().getTime() - new Date().getTime());
+                }
+                else{
+                    this.reset(Long.MAX_VALUE);
+                }
+            }
+        }
+        else{
+            if (roomContext.getCurrentMeeting().getEndDate().before(new Date())){
+                Meeting currentMeeting = roomContext.getCurrentMeeting();
+                ACLMessage msg = new ACLMessage(ACLMessage.INFORM);
+                Request request = new Request(currentMeeting, RequestStatus.FINISHED);
+                sendUpdateToUpkeeper(msg, request);
+                roomContext.setCurrentMeeting(null);
+                roomContext.removeMeeting(currentMeeting.getMeetingID());
+                this.reset(0);
+            }
+            else{
+                this.reset(1000);
+            }
+        }
+    }
+
+    private void fillAndSend(ACLMessage msg, Request request){
+        try {
+            myAgent.getContentManager().fillContent(msg, request);
+        } catch (Exception e){e.printStackTrace();}
+        myAgent.send(msg);
+    }
+
+    private void sendUpdateToUpkeeper(ACLMessage msg, Request request){
+        msg.setConversationId(roomContext.getCurrentMeeting().getMeetingID());
+        msg.setLanguage(new SLCodec().getName());
+        msg.setOntology(MeetingOntology.getInstance().getName());
+        msg.addReceiver(roomContext.getMyRoomUpkeeper());
+        fillAndSend(msg, request);
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgent.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgent.java
@@ -1,0 +1,83 @@
+package hvac.roomupkeeper;
+
+import hvac.ontologies.machinery.MachineryOntology;
+import hvac.ontologies.meeting.Meeting;
+import hvac.ontologies.roomclimate.RoomClimateOntology;
+import hvac.ontologies.weather.WeatherOntology;
+import hvac.roomupkeeper.behaviours.ClimateUpkeepingBehaviour;
+import hvac.time.DateTimeSimulator;
+import hvac.util.Conversions;
+import jade.content.lang.sl.SLCodec;
+import jade.core.AID;
+import jade.core.Agent;
+import jade.domain.FIPANames;
+
+import static hvac.util.Helpers.initTimeFromArgs;
+
+@SuppressWarnings("unused")
+public class RoomUpkeeperAgent extends Agent {
+    @Override
+    protected void setup() {
+        if(!initTimeFromArgs(this, this::usage)) return;
+        getContentManager().registerLanguage(new SLCodec(),
+                FIPANames.ContentLanguage.FIPA_SL0);
+        getContentManager().registerOntology(RoomClimateOntology.getInstance());
+        getContentManager().registerOntology(MachineryOntology.getInstance());
+        getContentManager().registerOntology(WeatherOntology.getInstance());
+
+        RoomUpkeeperContext context = getContext();
+        if(context == null) {
+            doDelete();
+            return;
+        }
+        context.getLogger().setAgentName("room upkeeper (" + context.getMyRoomId() + ")");
+        addBehaviour(new ClimateUpkeepingBehaviour(this, context));
+        context.setNextMeeting(new Meeting(
+                "abc",
+                Conversions.toDate(DateTimeSimulator.getCurrentDate().plusHours(2)),
+                Conversions.toDate(DateTimeSimulator.getCurrentDate().plusHours(4)),
+                5,
+                300.0f));
+    }
+
+    private RoomUpkeeperContext getContext() {
+        AID weatherForecaster = new AID("forecaster", false);
+        AID simulationAgent = new AID("simulation", false);
+        if(getArguments().length != 4) {
+            usage("incorrect number of arguments, required:4, provided: " + getArguments().length);
+            return null;
+        }
+        int myRoomId;
+        try {
+            myRoomId = Integer.parseInt(getArguments()[2].toString());
+        } catch (NumberFormatException e) {
+            usage("roomId is not valid");
+            return null;
+        }
+        if(myRoomId < 0) {
+            usage("roomId is not valid");
+        }
+        float myRoomArea;
+        try {
+            myRoomArea = Float.parseFloat(getArguments()[3].toString());
+        } catch (NumberFormatException e) {
+            usage("room area is not valid");
+            return null;
+        }
+        if(myRoomArea <= 0.0f) {
+            usage("room area is not valid");
+            return null;
+        }
+        return new RoomUpkeeperContext(weatherForecaster,simulationAgent,myRoomId, myRoomArea);
+    }
+
+    private void usage(String err) {
+        System.err.println("-------- Room upkeeper agent usage --------------");
+        System.err.println("roomUpkeeper:hvac.roomUpkeeper.RoomUpkeeperAgent(timeScale, start_date, roomId, roomArea)");
+        System.err.println("timescale - floating point value indicating speed of passing time");
+        System.err.println("Date from which to start simulating \"yyyy-MM-dd HH:mm:ss\"");
+        System.err.println("id of a room that will be upkept by this agent");
+        System.err.println("area in m^2 of a room that will be upkept by this agent");
+        System.err.println("err:" + err);
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
@@ -5,8 +5,8 @@ import hvac.util.Logger;
 import jade.core.AID;
 
 public class RoomUpkeeperContext {
-    private final AID weatherForecaster;
-    private final AID simulationAgent;
+    private AID weatherForecaster;
+    private AID simulationAgent;
     private final int myRoomId;
 
     /**
@@ -22,9 +22,7 @@ public class RoomUpkeeperContext {
     private final static float perM2RequiredVentilation = 0.0003f;//0.3L/s/m^2 = 0.0003m^3/s/m^2
     private final Logger logger = new Logger();
 
-    public RoomUpkeeperContext(AID weatherForecaster, AID simulationAgent, int myRoomId, float myRoomArea) {
-        this.weatherForecaster = weatherForecaster;
-        this.simulationAgent = simulationAgent;
+    public RoomUpkeeperContext(int myRoomId, float myRoomArea) {
         this.myRoomId = myRoomId;
         this.myRoomArea = myRoomArea;
         this.nextMeeting = null;
@@ -61,5 +59,13 @@ public class RoomUpkeeperContext {
 
     public Logger getLogger() {
         return logger;
+    }
+
+    public void setWeatherForecaster(AID weatherForecaster) {
+        this.weatherForecaster = weatherForecaster;
+    }
+
+    public void setSimulationAgent(AID simulationAgent) {
+        this.simulationAgent = simulationAgent;
     }
 }

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
@@ -1,0 +1,65 @@
+package hvac.roomupkeeper;
+
+import hvac.ontologies.meeting.Meeting;
+import hvac.util.Logger;
+import jade.core.AID;
+
+public class RoomUpkeeperContext {
+    private final AID weatherForecaster;
+    private final AID simulationAgent;
+    private final int myRoomId;
+
+    /**
+     * Next meeting that will be held in this room
+     * room will be accomodated to its required conditions
+     * is null if no new meeting is scheduled
+     */
+    private Meeting nextMeeting;
+    private static final float relativeHumidityToMaintain = 0.5f;
+    private final float myRoomArea;
+
+    private final static float perPersonRequiredVentilation = 0.0025f;//2.5L/s = 0.0025m^3/s
+    private final static float perM2RequiredVentilation = 0.0003f;//0.3L/s/m^2 = 0.0003m^3/s/m^2
+    private final Logger logger = new Logger();
+
+    public RoomUpkeeperContext(AID weatherForecaster, AID simulationAgent, int myRoomId, float myRoomArea) {
+        this.weatherForecaster = weatherForecaster;
+        this.simulationAgent = simulationAgent;
+        this.myRoomId = myRoomId;
+        this.myRoomArea = myRoomArea;
+        this.nextMeeting = null;
+    }
+
+    public Meeting getNextMeeting() {
+        return nextMeeting;
+    }
+
+    public void setNextMeeting(Meeting nextMeeting) {
+        this.nextMeeting = nextMeeting;
+    }
+
+    public AID getWeatherForecaster() {
+        return weatherForecaster;
+    }
+
+    public AID getSimulationAgent() {
+        return simulationAgent;
+    }
+
+    public int getMyRoomId() {
+        return myRoomId;
+    }
+
+    public float getRelativeHumidityToMaintain() {
+        return relativeHumidityToMaintain;
+    }
+
+    public float getRequiredVentilation() {
+        return (nextMeeting != null ? perPersonRequiredVentilation*nextMeeting.getPeopleInRoom() : 0.0f)
+                + perM2RequiredVentilation * myRoomArea;
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
+++ b/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
@@ -1,0 +1,402 @@
+package hvac.roomupkeeper.behaviours;
+
+import hvac.ontologies.machinery.*;
+import hvac.ontologies.roomclimate.RoomClimate;
+import hvac.ontologies.weather.Forecast;
+import hvac.ontologies.weather.WeatherSnapshot;
+import hvac.roomupkeeper.RoomUpkeeperContext;
+import hvac.roomupkeeper.data.RoomStatus;
+import hvac.simulation.SimulationAgentMessenger;
+import hvac.time.DateTimeSimulator;
+import hvac.util.Conversions;
+import hvac.util.Helpers;
+import hvac.util.Interpolation;
+import hvac.weatherforecaster.WeatherForecasterMessenger;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
+import jade.core.Agent;
+import jade.core.behaviours.CyclicBehaviour;
+import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public class ClimateUpkeepingBehaviour extends CyclicBehaviour {
+    private final RoomUpkeeperContext context;
+    private Step step = Step.INIT;
+    private MessageTemplate currentTemplate;
+    private static final int CLIMATE_FORGET_TIME_SECONDS = 3600 * 2;
+    private static final int MINUTES_BETWEEN_UPDATES = 3;
+    private static final float AIR_QUALITY_TOLERANCE = 0.05f;
+    private static final float POWER_TOLERANCE = 0.5f;
+    private static final float AIR_EXCHAGEND_PER_SECOND_TOLERANCE = 0.1f;
+    private LocalDateTime lastUpdate = LocalDateTime.MIN;
+
+    private enum Step {
+        INIT,
+        CLIMATE_WAIT_FOR_RESPONSE,
+        MACHINERY_INFO_WAIT_FOR_RESPONSE,
+        MACHINERY_UPDATE_WAIT_FOR_RESPONSE,
+        WEATHER_FORECASTER_WAIT_FOR_RESPONSE
+    }
+
+    private RoomClimate currentClimate = null;
+    private final List<RoomStatus> roomStatuses = new ArrayList<>();
+
+    private Machinery currentMachinery = null;
+    private List<WeatherSnapshot> weatherSnapshots = new ArrayList<>();
+    private boolean started = false;
+
+    public ClimateUpkeepingBehaviour(Agent a, RoomUpkeeperContext context) {
+        super(a);
+        this.context = context;
+    }
+
+    @Override
+    public void action() {
+        if(!started) {
+            started = true;
+            block(1000);
+            return;
+        }
+        roomStatuses.removeIf(status->status.getTime()
+                .isBefore(DateTimeSimulator.getCurrentDate().minusSeconds(CLIMATE_FORGET_TIME_SECONDS)));
+        if(context.getNextMeeting() != null && Conversions.toLocalDateTime(context.getNextMeeting().getEndDate())
+                .isBefore(DateTimeSimulator.getCurrentDate())) {
+            context.setNextMeeting(null);
+        }
+        switch (step) {
+            case INIT:
+                initStep();
+                break;
+            case MACHINERY_INFO_WAIT_FOR_RESPONSE:
+                machineryInfoWaitForResponseStep();
+                break;
+            case WEATHER_FORECASTER_WAIT_FOR_RESPONSE:
+                weatherForecasterWaitForResponseStep();
+                break;
+            case CLIMATE_WAIT_FOR_RESPONSE:
+                climateWaitForResponseStep();
+                break;
+            case MACHINERY_UPDATE_WAIT_FOR_RESPONSE:
+                machineryUpdateWaitForResponseStep();
+        }
+    }
+
+    private void initStep() {
+        if (context.getNextMeeting() == null) {
+            block();
+            return;
+        }
+        calculateNextClimate();
+    }
+
+
+    private void machineryInfoWaitForResponseStep() {
+        ACLMessage msg = myAgent.receive(currentTemplate);
+        if (msg != null) {
+            try {
+                Optional<MachineryStatus> machineryStatusOpt = SimulationAgentMessenger.extractMachineryStatus(myAgent, msg);
+                machineryStatusOpt.ifPresent(status -> currentMachinery = status.getMachinery());
+                if (!machineryStatusOpt.isPresent()) {
+                    throw new RuntimeException("simulation agent returns incorrect messages");
+                }
+            } catch (Codec.CodecException | OntologyException e) {
+                e.printStackTrace();
+            }
+            calculateNextClimate();
+        } else {
+            block();
+        }
+    }
+
+    private void weatherForecasterWaitForResponseStep() {
+        ACLMessage msg = myAgent.receive(currentTemplate);
+        if (msg != null) {
+            try {
+                Optional<Forecast> forecastOpt = WeatherForecasterMessenger.extractForecast(myAgent, msg);
+                forecastOpt.ifPresent(forecast -> weatherSnapshots = Conversions.toJavaList(forecast.getWeatherSnapshots()));
+                if (!forecastOpt.isPresent()) {
+                    throw new RuntimeException("weather forecaster agent returns incorrect messages");
+                }
+            } catch (Codec.CodecException | OntologyException e) {
+                e.printStackTrace();
+            }
+            calculateNextClimate();
+        } else {
+            block();
+        }
+    }
+    private void climateWaitForResponseStep() {
+        ACLMessage msg = myAgent.receive(currentTemplate);
+        if (msg != null) {
+            try {
+                Optional<RoomClimate> roomClimateOpt = SimulationAgentMessenger.extractRoomClimate(myAgent, msg);
+                roomClimateOpt.ifPresent(climate -> {
+                    LocalDateTime currentDate = DateTimeSimulator.getCurrentDate();
+                    if (currentClimate != null) {
+                        roomStatuses.add(new RoomStatus(
+                                (climate.getTemperature() - currentClimate.getTemperature()) /
+                                        ChronoUnit.SECONDS.between(
+                                                lastUpdate,
+                                                currentDate),
+                                currentMachinery.getHeater().getHeatingPower().getCurrentValue() -
+                                        currentMachinery.getAirConditioner().getCoolingPower().getCurrentValue(),
+                                currentDate));
+                    }
+                    currentClimate = climate;
+                });
+                if (!roomClimateOpt.isPresent()) {
+                    throw new RuntimeException("Simulation agent returns incorrect messages");
+                }
+                if(roomStatuses.size() == 0) {
+                    //get some more data required to kickstart the interpolation process
+                    lastUpdate = DateTimeSimulator.getCurrentDate();
+                    calculateNextClimate();
+                    return;
+                } else if(roomStatuses.size() == 1) {
+                    //kickstart the interpolation process
+                    //first and last points need to
+                        roomStatuses.add(new RoomStatus(
+                                100.0f,
+                                10000000.0f,
+                                LocalDateTime.MAX));
+                        roomStatuses.add(new RoomStatus(
+                                -100.0f,
+                                -10000000.0f,
+                                LocalDateTime.MAX));
+                    }
+                updateMachinery();
+            } catch (Codec.CodecException | OntologyException e) {
+                e.printStackTrace();
+            }
+        } else {
+            block();
+        }
+    }
+
+    private void machineryUpdateWaitForResponseStep() {
+        ACLMessage msg = myAgent.receive(currentTemplate);
+        if (msg != null) {
+            if(msg.getPerformative() == ACLMessage.AGREE) {
+                step = Step.INIT;
+                lastUpdate = DateTimeSimulator.getCurrentDate();
+            }
+            calculateNextClimate();
+        } else {
+            block();
+        }
+    }
+
+    private void calculateNextClimate() {
+        if (context.getNextMeeting() == null) {
+            step = Step.INIT;
+            return;
+        }
+        if (currentMachinery == null) {
+            enterMachineryInfoWaitForResponseStep();
+        } else if (weatherSnapshots.stream().noneMatch(snapshot ->
+                Conversions.toLocalDateTime(snapshot.getTime())
+                        .isAfter(DateTimeSimulator.getCurrentDate().plusDays(2)))) {
+            enterWeatherForecasterWaitForResponseStep();
+        } else if(DateTimeSimulator.getCurrentDate().isBefore(lastUpdate.plusMinutes(MINUTES_BETWEEN_UPDATES))) {
+            long blockTime = (long) (ChronoUnit.MILLIS.between(DateTimeSimulator.getCurrentDate(),
+                                lastUpdate.plusMinutes(MINUTES_BETWEEN_UPDATES))/DateTimeSimulator.getTimeScale());
+            step = Step.INIT;
+            if(blockTime > 0)
+                block(blockTime);
+        }  else {
+            enterClimateWaitForResponseStep();
+        }
+    }
+
+    private void updateMachinery() {
+        Machinery machinery = prepareNextRequiredMachinery();
+        if (!(machinery.getHeater() == null
+                && machinery.getAirConditioner() == null
+                && machinery.getVentilator() == null)) {
+            Helpers.updateMachinery(currentMachinery, machinery);
+            enterMachineryUpdateWaitForResponseStep(machinery);
+        } else {
+            lastUpdate = DateTimeSimulator.getCurrentDate();
+            calculateNextClimate();
+        }
+    }
+
+    private Machinery prepareNextRequiredMachinery() {
+        float requiredTemperatureSlope = getRequiredTemperatureSlope();
+        float requiredHeatingPower = calculateRequiredHeatingPower(requiredTemperatureSlope);
+        return new Machinery(
+                prepareNextAirConditioner(requiredHeatingPower),
+                prepareNextHeater(requiredHeatingPower),
+                prepareNextVentilator()
+        );
+    }
+
+    private float getRequiredTemperatureSlope() {
+
+        if(meetingInProgress()) {
+            return (context.getNextMeeting().getTemperature()
+                    - currentClimate.getTemperature()) / ChronoUnit.SECONDS.between(
+                    DateTimeSimulator.getCurrentDate(),
+                    DateTimeSimulator.getCurrentDate().plusMinutes(MINUTES_BETWEEN_UPDATES));
+        }
+        else {
+            return (context.getNextMeeting().getTemperature()
+                    - currentClimate.getTemperature()) / ChronoUnit.SECONDS.between(
+                    DateTimeSimulator.getCurrentDate(),
+                    Conversions.toLocalDateTime(context.getNextMeeting().getStartDate()));
+        }
+    }
+
+    private AirConditioner prepareNextAirConditioner(float requiredHeatingPower) {
+        if (requiredHeatingPower < -POWER_TOLERANCE) {
+            return new AirConditioner(
+                    new MachineParameter(
+                            currentMachinery.getAirConditioner().getAirExchangedPerSecond().getMaxValue(), null),
+                    new MachineParameter(
+                            -requiredHeatingPower, null));
+        } else if (!Helpers.almostEqual(
+                0.0f,
+                currentMachinery.getHeater().getHeatingPower().getCurrentValue(),
+                POWER_TOLERANCE)) {
+            return new AirConditioner(
+                    new MachineParameter(
+                            0.0f, null),
+                    new MachineParameter(
+                            0.0f, null));
+        }
+        return null;
+    }
+
+    private Ventilator prepareNextVentilator() {
+        if (!Helpers.almostEqual(
+                currentMachinery.getVentilator().getAirExchangedPerSecond().getCurrentValue(),
+                context.getRequiredVentilation(),
+                AIR_EXCHAGEND_PER_SECOND_TOLERANCE)) {
+            if (currentClimate.getAirQuality() < 1-AIR_QUALITY_TOLERANCE &&
+                    !Helpers.almostEqual(
+                            currentMachinery.getVentilator().getAirExchangedPerSecond().getCurrentValue(),
+                            currentMachinery.getVentilator().getAirExchangedPerSecond().getMaxValue(),
+                            AIR_EXCHAGEND_PER_SECOND_TOLERANCE)) {
+                return new Ventilator(
+                        new MachineParameter(context.getRequiredVentilation(), null));
+            }
+            if (currentClimate.getAirQuality() > 1+AIR_QUALITY_TOLERANCE &&
+                    !Helpers.almostEqual(
+                            currentMachinery.getVentilator().getAirExchangedPerSecond().getCurrentValue(),
+                            0, AIR_EXCHAGEND_PER_SECOND_TOLERANCE)) {
+                return new Ventilator(
+                        new MachineParameter(context.getRequiredVentilation(), null));
+            }
+        }
+        return null;
+    }
+
+    private Heater prepareNextHeater(float requiredHeatingPower) {
+        if (requiredHeatingPower > POWER_TOLERANCE) {
+            return new Heater(new MachineParameter(
+                    requiredHeatingPower, null
+            ));
+        } else if (!Helpers.almostEqual(
+                0.0f,
+                currentMachinery.getHeater().getHeatingPower().getCurrentValue(),
+                POWER_TOLERANCE)) {
+            return new Heater(new MachineParameter(
+                    0.0f, null
+            ));
+        }
+        return null;
+    }
+
+    private float calculateRequiredHeatingPower(float requiredTemperatureSlope) {
+        List<Float> arguments = new ArrayList<>();
+        List<Float> values = new ArrayList<>();
+        roomStatuses.stream()
+                .sorted(Comparator.comparing(RoomStatus::getTemperatureSlope))
+                .forEachOrdered(status-> {
+                    arguments.add(status.getTemperatureSlope());
+                    values.add(status.getHeatingPower());
+                });
+        float unboundRequiredHeatingPower = Interpolation.calculateValueAt(requiredTemperatureSlope,
+                arguments, values);
+        return Math.max(Math.min(unboundRequiredHeatingPower,
+                currentMachinery.getHeater().getHeatingPower().getMaxValue()),
+                -currentMachinery.getAirConditioner().getAirExchangedPerSecond().getMaxValue());
+
+    }
+
+    private boolean meetingInProgress() {
+        return Conversions.toLocalDateTime(
+                context.getNextMeeting().getStartDate())
+                .isBefore(DateTimeSimulator.getCurrentDate())
+                && Conversions.toLocalDateTime(
+                context.getNextMeeting().getEndDate())
+                .isAfter(DateTimeSimulator.getCurrentDate());
+    }
+
+    private void enterMachineryInfoWaitForResponseStep() {
+        context.getLogger().log("entering MachineryInfoWaitForResponseStep");
+        try {
+            ACLMessage msg = SimulationAgentMessenger.prepareReportMachineryStatus(
+                    context.getMyRoomId(), myAgent, context.getSimulationAgent());
+            myAgent.send(msg);
+            currentTemplate = MessageTemplate.MatchSender(context.getSimulationAgent());
+            step = Step.MACHINERY_INFO_WAIT_FOR_RESPONSE;
+        } catch (Codec.CodecException | OntologyException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void enterWeatherForecasterWaitForResponseStep() {
+        context.getLogger().log("entering WeatherForecasterWaitForResponseStep");
+        try {
+            ACLMessage msg = WeatherForecasterMessenger.prepareForecastRequest(
+                    DateTimeSimulator.getCurrentDate(),
+                    DateTimeSimulator.getCurrentDate().plusWeeks(1),
+                    myAgent,
+                    context.getWeatherForecaster());
+            myAgent.send(msg);
+            currentTemplate = MessageTemplate.MatchSender(context.getWeatherForecaster());
+            step = Step.WEATHER_FORECASTER_WAIT_FOR_RESPONSE;
+        } catch (Codec.CodecException | OntologyException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void enterClimateWaitForResponseStep() {
+        context.getLogger().log("entering ClimateWaitForResponseStep");
+        try {
+            ACLMessage msg = SimulationAgentMessenger.prepareInfoRequest(
+                    context.getMyRoomId(),
+                    myAgent,
+                    context.getSimulationAgent());
+            myAgent.send(msg);
+            currentTemplate = MessageTemplate.MatchSender(context.getSimulationAgent());
+            step = Step.CLIMATE_WAIT_FOR_RESPONSE;
+        } catch (Codec.CodecException | OntologyException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void enterMachineryUpdateWaitForResponseStep(Machinery update) {
+        context.getLogger().log("entering MachineryUpdateWaitForResponseStep");
+        try {
+            ACLMessage msg = SimulationAgentMessenger.prepareUpdateMachinery(
+                    update,
+                    context.getMyRoomId(),
+                    myAgent,
+                    context.getSimulationAgent());
+            myAgent.send(msg);
+            currentTemplate = MessageTemplate.MatchSender(context.getSimulationAgent());
+            step = Step.MACHINERY_UPDATE_WAIT_FOR_RESPONSE;
+        } catch (Codec.CodecException | OntologyException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
+++ b/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
@@ -51,7 +51,6 @@ public class ClimateUpkeepingBehaviour extends CyclicBehaviour {
 
     private Machinery currentMachinery = null;
     private List<WeatherSnapshot> weatherSnapshots = new ArrayList<>();
-    private boolean started = false;
 
     public ClimateUpkeepingBehaviour(Agent a, RoomUpkeeperContext context) {
         super(a);
@@ -60,12 +59,6 @@ public class ClimateUpkeepingBehaviour extends CyclicBehaviour {
 
     @Override
     public void action() {
-        //wait for other agents to initialize
-        if (!started) {
-            started = true;
-            block(1000);
-            return;
-        }
         //remove expired statuses, so only recent data is used in interpolation
         roomStatuses.removeIf(status -> status.getTime()
                 .isBefore(DateTimeSimulator.getCurrentDate().minusSeconds(CLIMATE_FORGET_TIME_SECONDS)));

--- a/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
+++ b/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
@@ -6,15 +6,15 @@ public class RoomStatus {
     private float temperatureSlope;
     private float humiditySlope;
     /**
-     * positive - power of the heater
-     * negative - power of the air conditioner
+     * positive -> heater.power=value, ac.power = 0
+     * negative -> heater.power = 0, ac.power = -value
      */
     private float heatingPower;
     /**
-     * positive - air exchanged per second by ventilation - minimal required ventilation
-     * negative - air exchanged per second by air conditioning - minimal required ventilation
-     * so it is zero when ventilation works on minimal required aeps
-     * and ac works enough to counteract humidification created by ventilation
+     * positive -> ac.airPerSecond = 0, ventilation.airPerSecond = value + minimalRequiredVentilation
+     * negative -> ac.airPerSecond = -value, ventilation.airPerSecond = minimalRequiredVentilation
+     * so its the same as with heating power -> ac counteracts ventilation - its just that the tipping point is not at zero
+     * but at minimalRequiredVentilation
      */
     private float airExchangedPerSecond;
     private LocalDateTime time;

--- a/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
+++ b/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
@@ -1,0 +1,39 @@
+package hvac.roomupkeeper.data;
+
+import java.time.LocalDateTime;
+
+public class RoomStatus {
+    private float temperatureSlope;
+    private float heatingPower;
+    private LocalDateTime time;
+
+    public RoomStatus(float temperatureSlope, float heatingPower, LocalDateTime time) {
+        this.temperatureSlope = temperatureSlope;
+        this.heatingPower = heatingPower;
+        this.time = time;
+    }
+
+    public float getTemperatureSlope() {
+        return temperatureSlope;
+    }
+
+    public void setTemperatureSlope(float temperatureSlope) {
+        this.temperatureSlope = temperatureSlope;
+    }
+
+    public float getHeatingPower() {
+        return heatingPower;
+    }
+
+    public void setHeatingPower(float heatingPower) {
+        this.heatingPower = heatingPower;
+    }
+
+    public LocalDateTime getTime() {
+        return time;
+    }
+
+    public void setTime(LocalDateTime time) {
+        this.time = time;
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
+++ b/src/main/java/hvac/roomupkeeper/data/RoomStatus.java
@@ -4,12 +4,26 @@ import java.time.LocalDateTime;
 
 public class RoomStatus {
     private float temperatureSlope;
+    private float humiditySlope;
+    /**
+     * positive - power of the heater
+     * negative - power of the air conditioner
+     */
     private float heatingPower;
+    /**
+     * positive - air exchanged per second by ventilation - minimal required ventilation
+     * negative - air exchanged per second by air conditioning - minimal required ventilation
+     * so it is zero when ventilation works on minimal required aeps
+     * and ac works enough to counteract humidification created by ventilation
+     */
+    private float airExchangedPerSecond;
     private LocalDateTime time;
 
-    public RoomStatus(float temperatureSlope, float heatingPower, LocalDateTime time) {
+    public RoomStatus(float temperatureSlope, float humiditySlope, float heatingPower, float airExchangedPerSecond, LocalDateTime time) {
         this.temperatureSlope = temperatureSlope;
+        this.humiditySlope = humiditySlope;
         this.heatingPower = heatingPower;
+        this.airExchangedPerSecond = airExchangedPerSecond;
         this.time = time;
     }
 
@@ -35,5 +49,21 @@ public class RoomStatus {
 
     public void setTime(LocalDateTime time) {
         this.time = time;
+    }
+
+    public float getHumiditySlope() {
+        return humiditySlope;
+    }
+
+    public void setHumiditySlope(float humiditySlope) {
+        this.humiditySlope = humiditySlope;
+    }
+
+    public float getAirExchangedPerSecond() {
+        return airExchangedPerSecond;
+    }
+
+    public void setAirExchangedPerSecond(float airExchangedPerSecond) {
+        this.airExchangedPerSecond = airExchangedPerSecond;
     }
 }

--- a/src/main/java/hvac/simulation/SimulationAgent.java
+++ b/src/main/java/hvac/simulation/SimulationAgent.java
@@ -14,6 +14,7 @@ import hvac.simulation.rooms.Room;
 import hvac.simulation.rooms.RoomClimate;
 import hvac.simulation.rooms.RoomWall;
 import hvac.time.DateTimeSimulator;
+import hvac.util.df.DfHelpers;
 import hvac.weather.DatabaseForecastProvider;
 import jade.content.lang.sl.SLCodec;
 import jade.core.Agent;
@@ -28,6 +29,7 @@ public class SimulationAgent extends Agent {
     @Override
     protected void setup() {
         if(!initTimeFromArgs(this, this::usage)) return;
+        if(!DfHelpers.tryRegisterInDfWithServiceName(this, "simulation")) return;
         simulationContext.getLogger().setAgentName("simulation");
         getContentManager().registerLanguage(new SLCodec(),
                 FIPANames.ContentLanguage.FIPA_SL0);

--- a/src/main/java/hvac/simulation/SimulationAgentMessenger.java
+++ b/src/main/java/hvac/simulation/SimulationAgentMessenger.java
@@ -1,12 +1,9 @@
 package hvac.simulation;
 
-import hvac.ontologies.machinery.Machinery;
-import hvac.ontologies.machinery.MachineryOntology;
-import hvac.ontologies.machinery.ReportMachineryStatus;
-import hvac.ontologies.machinery.UpdateMachinery;
+import hvac.ontologies.machinery.*;
 import hvac.ontologies.roomclimate.InfoRequest;
 import hvac.ontologies.roomclimate.RoomClimate;
-import hvac.ontologies.weather.WeatherOntology;
+import hvac.ontologies.roomclimate.RoomClimateOntology;
 import jade.content.ContentElement;
 import jade.content.lang.Codec;
 import jade.content.onto.Ontology;
@@ -32,12 +29,12 @@ public class SimulationAgentMessenger {
      * @param simulationAgent simulation agent to which message will be sent
      * @return prepared message
      * @throws Codec.CodecException language fipa-sl0 is not registered
-     * @throws OntologyException weather ontology is not registered
+     * @throws OntologyException room climate ontology is not registered
      */
     public static ACLMessage prepareInfoRequest(int roomId, Agent myAgent, AID simulationAgent)
             throws Codec.CodecException, OntologyException {
         InfoRequest request = new InfoRequest(roomId);
-        return createActionMessage(myAgent, simulationAgent, request, WeatherOntology.getInstance());
+        return createActionMessage(myAgent, simulationAgent, request, RoomClimateOntology.getInstance());
     }
 
 
@@ -48,7 +45,7 @@ public class SimulationAgentMessenger {
      * @param msg message with room climate
      * @return extracted room climate if message contains one
      * @throws Codec.CodecException language fipa-sl0 is not registered or message received is not in this language
-     * @throws OntologyException weather ontology is not registered or message received is not in this ontology
+     * @throws OntologyException room climate ontology is not registered or message received is not in this ontology
      */
     public static Optional<RoomClimate> extractRoomClimate(Agent myAgent, ACLMessage msg)
             throws Codec.CodecException, OntologyException {
@@ -67,7 +64,7 @@ public class SimulationAgentMessenger {
      * @param simulationAgent simulation agent to which message will be sent
      * @return prepared message
      * @throws Codec.CodecException language fipa-sl0 is not registered
-     * @throws OntologyException weather ontology is not registered
+     * @throws OntologyException machinery ontology is not registered
      */
     public static ACLMessage prepareReportMachineryStatus(int roomId, Agent myAgent, AID simulationAgent)
             throws Codec.CodecException, OntologyException {
@@ -83,13 +80,13 @@ public class SimulationAgentMessenger {
      * @param msg message with room climate
      * @return extracted machinery status if message contains one
      * @throws Codec.CodecException language fipa-sl0 is not registered or message received is not in this language
-     * @throws OntologyException weather ontology is not registered or message received is not in this ontology
+     * @throws OntologyException machinery ontology is not registered or message received is not in this ontology
      */
-    public static Optional<RoomClimate> extractMachineryStatus(Agent myAgent, ACLMessage msg)
+    public static Optional<MachineryStatus> extractMachineryStatus(Agent myAgent, ACLMessage msg)
             throws Codec.CodecException, OntologyException {
         ContentElement content = myAgent.getContentManager().extractContent(msg);
-        if(content instanceof RoomClimate) {
-            return Optional.of((RoomClimate)content);
+        if(content instanceof MachineryStatus) {
+            return Optional.of((MachineryStatus)content);
         }
         return Optional.empty();
     }
@@ -102,7 +99,7 @@ public class SimulationAgentMessenger {
      * @param simulationAgent simulation agent to which message will be sent
      * @return prepared message
      * @throws Codec.CodecException language fipa-sl0 is not registered
-     * @throws OntologyException weather ontology is not registered
+     * @throws OntologyException machinery ontology is not registered
      */
     public static ACLMessage prepareUpdateMachinery(Machinery machinery, int roomId, Agent myAgent, AID simulationAgent)
             throws Codec.CodecException, OntologyException {

--- a/src/main/java/hvac/simulation/SimulationContext.java
+++ b/src/main/java/hvac/simulation/SimulationContext.java
@@ -2,6 +2,7 @@ package hvac.simulation;
 
 import hvac.simulation.rooms.RoomClimate;
 import hvac.simulation.rooms.RoomMap;
+import hvac.util.Logger;
 
 import java.util.Hashtable;
 
@@ -9,6 +10,7 @@ public class SimulationContext {
     private final RoomMap roomMap = new RoomMap();
     private final Hashtable<Integer, RoomClimate> climates = new Hashtable<>();
     private final OutsideClimate outsideClimate = new OutsideClimate();
+    private final Logger logger = new Logger();
 
     public RoomMap getRoomMap() {
         return roomMap;
@@ -20,5 +22,9 @@ public class SimulationContext {
 
     public OutsideClimate getOutsideClimate() {
         return outsideClimate;
+    }
+
+    public Logger getLogger() {
+        return logger;
     }
 }

--- a/src/main/java/hvac/simulation/behaviours/ClimateInformingBehaviour.java
+++ b/src/main/java/hvac/simulation/behaviours/ClimateInformingBehaviour.java
@@ -63,6 +63,8 @@ public class ClimateInformingBehaviour extends CyclicBehaviour {
                     ACLMessage reply = msg.createReply();
                     reply.setPerformative(ACLMessage.INFORM);
                     myAgent.getContentManager().fillContent(reply, roomClimate);
+                    context.getLogger().log("replying to climate request: roomId: " + infoRequest.getRoomId() +
+                            ", temperature: " + roomClimate.getTemperature());
                     myAgent.send(reply);
                 } else {
                     replyRefuse(msg);

--- a/src/main/java/hvac/simulation/behaviours/ClimateInformingBehaviour.java
+++ b/src/main/java/hvac/simulation/behaviours/ClimateInformingBehaviour.java
@@ -64,7 +64,8 @@ public class ClimateInformingBehaviour extends CyclicBehaviour {
                     reply.setPerformative(ACLMessage.INFORM);
                     myAgent.getContentManager().fillContent(reply, roomClimate);
                     context.getLogger().log("replying to climate request: roomId: " + infoRequest.getRoomId() +
-                            ", temperature: " + roomClimate.getTemperature());
+                            ", temperature: " + roomClimate.getTemperature() +
+                            ", relative humidity: " + roomClimate.getRelativeHumidity());
                     myAgent.send(reply);
                 } else {
                     replyRefuse(msg);

--- a/src/main/java/hvac/simulation/behaviours/ClimateUpdatingBehaviour.java
+++ b/src/main/java/hvac/simulation/behaviours/ClimateUpdatingBehaviour.java
@@ -165,7 +165,7 @@ public class ClimateUpdatingBehaviour extends TickerBehaviour {
         float saturationWaterVapour = (float)(pressureFunctionValue * 6.112
                 * Math.exp(17.62*tempCelsius/(243.12+tempCelsius)));
         float currentWaterVapour = newClimate.getAbsoluteHumidity() * 461.5f * newClimate.getTemperature();
-        return currentWaterVapour/saturationWaterVapour;
+        return currentWaterVapour/saturationWaterVapour*0.01f;
     }
 
     private float calculateAirQualityFor(Room r, RoomClimate oldClimate) {

--- a/src/main/java/hvac/time/DateTimeSimulator.java
+++ b/src/main/java/hvac/time/DateTimeSimulator.java
@@ -20,4 +20,8 @@ public class DateTimeSimulator {
         double diff = (double)(realCurrentDate - realStartDate) * timeScale * 0.001f;
         return startDate.plusSeconds((long)diff);
     }
+
+    public static float getTimeScale() {
+        return timeScale;
+    }
 }

--- a/src/main/java/hvac/util/Conversions.java
+++ b/src/main/java/hvac/util/Conversions.java
@@ -6,7 +6,10 @@ import hvac.simulation.rooms.RoomClimate;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class Conversions {
     public static LocalDateTime toLocalDateTime(Date date) {
@@ -37,5 +40,14 @@ public class Conversions {
 
     public static hvac.ontologies.machinery.MachineParameter toOntologyParameter(hvac.simulation.machinery.MachineParameter parameter) {
         return new MachineParameter(parameter.getCurrentValue(), parameter.getMaxValue());
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> toJavaList(jade.util.leap.List jadeList) {
+        try {
+            return Arrays.stream(jadeList.toArray()).map(it->(T)it).collect(Collectors.toList());
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException("elements of given jade list are not of type required for result list");
+        }
     }
 }

--- a/src/main/java/hvac/util/Helpers.java
+++ b/src/main/java/hvac/util/Helpers.java
@@ -1,9 +1,65 @@
 package hvac.util;
 
+import hvac.ontologies.machinery.Machinery;
+import hvac.time.DateTimeSimulator;
+import jade.core.Agent;
+
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Optional;
+import java.util.function.Consumer;
 
 public class Helpers {
     public static boolean isBetween(LocalDateTime date, LocalDateTime start, LocalDateTime end) {
         return date.isAfter(start) && date.isBefore(end);
+    }
+
+    public static boolean initTimeFromArgs(Agent agent, Consumer<String> usageFunction) {
+        Object[] arguments = agent.getArguments();
+        if (arguments == null || arguments.length < 2) {
+            usageFunction.accept("Wrong args num");
+            agent.doDelete();
+            return false;
+        }
+        LocalDateTime startTime;
+        float timeScale;
+        try {
+            timeScale = Float.parseFloat(arguments[0].toString());
+            startTime = LocalDateTime.parse(arguments[1].toString(),
+                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        } catch (NumberFormatException | DateTimeParseException e) {
+            usageFunction.accept(e.getMessage());
+            agent.doDelete();
+            return false;
+        }
+        DateTimeSimulator.init(startTime, timeScale);
+        return true;
+    }
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public static boolean almostEqual(float f1, float f2, float epsilon) {
+        return Math.abs(f1-f2)<epsilon;
+    }
+    public static void updateMachinery(Machinery updatedMachinery, Machinery updatingMachinery) {
+        Optional.ofNullable(updatingMachinery.getAirConditioner()).ifPresent(airConditioner -> {
+            Optional.ofNullable(airConditioner.getCoolingPower())
+                    .ifPresent(coolingPower ->
+                            updatedMachinery.getAirConditioner().getCoolingPower()
+                                    .setCurrentValue(coolingPower.getCurrentValue()));
+            Optional.ofNullable(airConditioner.getAirExchangedPerSecond())
+                    .ifPresent(airExchangedPerSecond ->
+                            updatedMachinery.getAirConditioner().getAirExchangedPerSecond()
+                                    .setCurrentValue(airExchangedPerSecond.getCurrentValue()));
+        });
+        Optional.ofNullable(updatingMachinery.getHeater())
+                .flatMap(heater -> Optional.ofNullable(heater.getHeatingPower()))
+                .ifPresent(heatingPower ->
+                        updatedMachinery.getHeater().getHeatingPower()
+                                .setCurrentValue(heatingPower.getCurrentValue()));
+        Optional.ofNullable(updatingMachinery.getVentilator())
+                .flatMap(ventilator -> Optional.ofNullable(ventilator.getAirExchangedPerSecond()))
+                .ifPresent(airExchangedPerSecond ->
+                        updatedMachinery.getVentilator().getAirExchangedPerSecond()
+                                .setCurrentValue(airExchangedPerSecond.getCurrentValue()));
     }
 }

--- a/src/main/java/hvac/util/Interpolation.java
+++ b/src/main/java/hvac/util/Interpolation.java
@@ -1,0 +1,17 @@
+package hvac.util;
+
+import org.apache.commons.math3.analysis.interpolation.SplineInterpolator;
+
+import java.util.List;
+
+
+public class Interpolation {
+    public static float calculateValueAt(float x, List<Float> knownX, List<Float> knownY) {
+        if(knownX.size() != knownY.size()) {
+            throw new IllegalArgumentException("input lists must be of the same length");
+        }
+        double[] xArray = knownX.stream().mapToDouble(Float::doubleValue).toArray();
+        double[] yArray = knownY.stream().mapToDouble(Float::doubleValue).toArray();
+        return (float) new SplineInterpolator().interpolate(xArray,yArray).value(x);
+    }
+}

--- a/src/main/java/hvac/util/Logger.java
+++ b/src/main/java/hvac/util/Logger.java
@@ -1,0 +1,23 @@
+package hvac.util;
+
+import hvac.time.DateTimeSimulator;
+
+import java.time.format.DateTimeFormatter;
+
+public class Logger {
+    private String agentName = "unnamed agent";
+    private DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    public void log(String msg) {
+        System.out.println("[" + DateTimeSimulator.getCurrentDate().format(formatter) + "]"
+        + agentName + ": " + msg);
+    }
+
+    public String getAgentName() {
+        return agentName;
+    }
+
+    public void setAgentName(String agentName) {
+        this.agentName = agentName;
+    }
+}

--- a/src/main/java/hvac/util/df/DfHelpers.java
+++ b/src/main/java/hvac/util/df/DfHelpers.java
@@ -1,0 +1,26 @@
+package hvac.util.df;
+
+import jade.core.Agent;
+import jade.domain.DFService;
+import jade.domain.FIPAAgentManagement.DFAgentDescription;
+import jade.domain.FIPAAgentManagement.ServiceDescription;
+import jade.domain.FIPAException;
+
+public class DfHelpers {
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    public static boolean tryRegisterInDfWithServiceName(Agent agent, String serviceName) {
+        DFAgentDescription description = new DFAgentDescription();
+        description.setName(agent.getAID());
+        ServiceDescription sd = new ServiceDescription();
+        sd.setName(serviceName);
+        sd.setType("hvac");
+        description.addServices(sd);
+        try {
+            DFService.register(agent,description);
+        } catch (FIPAException e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/hvac/util/df/FindingBehaviour.java
+++ b/src/main/java/hvac/util/df/FindingBehaviour.java
@@ -1,0 +1,65 @@
+package hvac.util.df;
+
+import jade.core.Agent;
+import jade.core.behaviours.CyclicBehaviour;
+import jade.domain.DFService;
+import jade.domain.FIPAAgentManagement.DFAgentDescription;
+import jade.domain.FIPAAgentManagement.SearchConstraints;
+import jade.domain.FIPAAgentManagement.ServiceDescription;
+import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
+
+import java.util.function.Consumer;
+
+/**
+ * Asks Directory facilitator for agent with given service name
+ * when it receives response it calls provided function and removes itself
+ */
+public class FindingBehaviour extends CyclicBehaviour {
+    DFAgentDescription agentToFind;
+    Consumer<DFAgentDescription> afterFound;
+    boolean messageSent;
+    public FindingBehaviour(Agent agent, String nameOfAgentToFind,
+                        Consumer<DFAgentDescription> afterFound) {
+        super(agent);
+        this.agentToFind = new DFAgentDescription();
+        ServiceDescription sd = new ServiceDescription();
+        sd.setName(nameOfAgentToFind);
+        agentToFind.addServices(sd);
+        this.afterFound = afterFound;
+    }
+
+    @Override
+    public void action()
+    {
+        if(!messageSent) {
+            sendMessage();
+            messageSent = true;
+        }
+        ACLMessage msg =
+                myAgent.receive(MessageTemplate.MatchSender(myAgent.getDefaultDF()));
+
+        if (msg != null)
+        {
+            try {
+                DFAgentDescription[] dfds =
+                        DFService.decodeNotification(msg.getContent());
+                if (dfds.length > 0) {
+                    afterFound.accept(dfds[0]);
+                    myAgent.removeBehaviour(this);
+                }
+            }
+            catch (Exception ex) {/*just wait for another message*/}
+        }
+        block();
+
+    }
+
+    private void sendMessage() {
+        SearchConstraints sc = new SearchConstraints();
+        sc.setMaxResults((long) 1);
+
+        myAgent.send(DFService.createSubscriptionMessage(myAgent, myAgent.getDefaultDF(),
+                agentToFind, sc));
+    }
+}

--- a/src/main/java/hvac/weatherforecaster/WeatherForecasterAgent.java
+++ b/src/main/java/hvac/weatherforecaster/WeatherForecasterAgent.java
@@ -4,6 +4,7 @@ import hvac.database.Connection;
 import hvac.database.entities.WeatherSnapshot;
 import hvac.ontologies.weather.WeatherOntology;
 import hvac.time.DateTimeSimulator;
+import hvac.util.df.DfHelpers;
 import hvac.weather.DatabaseForecastProvider;
 import hvac.weather.interfaces.ForecastProvider;
 import hvac.weatherforecaster.behaviours.ForecastProvidingBehaviour;
@@ -12,11 +13,10 @@ import jade.content.lang.sl.SLCodec;
 import jade.core.Agent;
 import jade.domain.FIPANames;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static hvac.util.Helpers.initTimeFromArgs;
 
 @SuppressWarnings("unused")
 public class WeatherForecasterAgent extends Agent {
@@ -24,29 +24,14 @@ public class WeatherForecasterAgent extends Agent {
 
     @Override
     protected void setup() {
-        if (getArguments() == null || getArguments().length != 2) {
-            usage("Wrong args num");
-            doDelete();
-            return;
-        }
-        LocalDateTime startTime;
-        float timeScale;
-        try {
-            timeScale = Float.parseFloat(getArguments()[0].toString());
-            startTime = LocalDateTime.parse(getArguments()[1].toString(),
-                    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        } catch (NumberFormatException | DateTimeParseException e) {
-            usage(e.getMessage());
-            doDelete();
-            return;
-        }
-        DateTimeSimulator.init(startTime, timeScale);
+        if(!initTimeFromArgs(this, this::usage)) return;
+        if(!DfHelpers.tryRegisterInDfWithServiceName(this, "weather-forecaster")) return;
         getContentManager().registerLanguage(new SLCodec(),
                 FIPANames.ContentLanguage.FIPA_SL0);
         getContentManager().registerOntology(WeatherOntology.getInstance());
         Connection database = new Connection();
         ForecastProvider provider = new DatabaseForecastProvider(database);
-        int weatherGettingSpeed = (int)(1000*3600/timeScale);
+        int weatherGettingSpeed = (int)(1000*3600/DateTimeSimulator.getTimeScale());
         addBehaviour(new WeatherGettingBehaviour(this, weatherGettingSpeed, provider, oneWeekPlusWeather));
         addBehaviour(new ForecastProvidingBehaviour(this, oneWeekPlusWeather));
     }

--- a/src/main/java/hvac/weatherforecaster/WeatherForecasterMessenger.java
+++ b/src/main/java/hvac/weatherforecaster/WeatherForecasterMessenger.java
@@ -3,6 +3,7 @@ package hvac.weatherforecaster;
 import hvac.ontologies.weather.Forecast;
 import hvac.ontologies.weather.ForecastRequest;
 import hvac.ontologies.weather.WeatherOntology;
+import hvac.util.Conversions;
 import jade.content.ContentElement;
 import jade.content.lang.Codec;
 import jade.content.onto.OntologyException;
@@ -12,6 +13,7 @@ import jade.core.Agent;
 import jade.domain.FIPANames;
 import jade.lang.acl.ACLMessage;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 /**
@@ -21,20 +23,24 @@ public class WeatherForecasterMessenger {
     /**
      * prepares message that when sent to Weather forecaster will result in correct snapshot
      * Requires that agent has registered sl0 language and weather ontology
-     * @param request request to send to forecaster
+     * @param from oldest date that provided forecast can have
+     * @param to newest date that provided forecasts can have
      * @param myAgent agent that will send the message
      * @param forecaster forecaster to which message will be sent
      * @return prepared message
      * @throws Codec.CodecException
      * @throws OntologyException
      */
-    public static ACLMessage prepareForecastRequest(ForecastRequest request, Agent myAgent, AID forecaster)
+    public static ACLMessage prepareForecastRequest(LocalDateTime from, LocalDateTime to, Agent myAgent, AID forecaster)
             throws Codec.CodecException, OntologyException {
         ACLMessage msg = new ACLMessage(ACLMessage.REQUEST);
         msg.addReceiver(forecaster);
         msg.setLanguage(FIPANames.ContentLanguage.FIPA_SL0);
         msg.setOntology(WeatherOntology.getInstance().getName());
-        Action action = new Action(forecaster, request);
+        Action action = new Action(forecaster, new ForecastRequest(
+                Conversions.toDate(from),
+                Conversions.toDate(to)
+        ));
         myAgent.getContentManager().fillContent(msg, action);
         return msg;
     }


### PR DESCRIPTION
Zawiera zmiany z #16 więc wcześniej trzeba tamto zmergować. Użycie directory facilitator zapewnia, że agenci do których wysyłamy wiadomości już są dostępni i nie musimy polegać na nazwie wejściowej agentów do ich rozpoznawania.
@DLZaan chyba lepiej będzie jak w room coordinatorze też to wprowadzisz, bo co podasz jako AID sąsiadów w argumentach wejściowych jak do utworzenia sąsiadów trzeba AID danego room coordinatora? Lepiej jako argument wejściowy podać chyba id pokoju danego sąsiada, a agent sam sobie go znajdzie, tak samo podać mu id jego pokoju jako argument wejściowy a on ustali swoją nazwę usługi oraz znajdzie na podstawie tego id swojego upkeepera. 