### PR TITLE
Coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Select Delegate IDE build/run actions to Maven and apply
 In top right corner press Add configuration.
 Click the + button and choose application.
 Select jade.Boot as the main class and specify arguments, for example:
--gui -agents a:HelloWorldAgent
+1. (dummy to check if JADE is working) -gui -agents a:HelloWorldAgent
+2. (to run current build) -gui -agents simulation:hvac.simulation.SimulationAgent(20,"2015-05-20 10:20:00")
 
 You can name this configuration appropriately.
 

--- a/src/main/java/hvac/coordinator/CoordinatorAgent.java
+++ b/src/main/java/hvac/coordinator/CoordinatorAgent.java
@@ -6,6 +6,8 @@ import hvac.calendar.CalendarWrapper;
 import hvac.coordinator.behaviours.MeetingUpdatingBehaviour;
 import hvac.database.Connection;
 import hvac.ontologies.meeting.MeetingOntology;
+import hvac.roomcoordinator.RoomCoordinatorAgent;
+import hvac.roomupkeeper.RoomUpkeeperAgent;
 import hvac.simulation.rooms.Room;
 import hvac.simulation.rooms.RoomLink;
 import hvac.simulation.rooms.RoomMap;
@@ -64,11 +66,11 @@ public class CoordinatorAgent extends Agent {
             }
             try {
                 newContainer.createNewAgent("room-coordinator-" + room.getId(),
-                        "hvac.roomcoordinator.RoomCoordinatorAgent",
+                        RoomCoordinatorAgent.class.getCanonicalName(),
                         new Object[]{room.getId(), getAID(), myNeighboursIds, myWalls}).start();
 
                 newContainer.createNewAgent("upkeeper-" + room.getId(),
-                        "hvac.roomupkeeper.RoomUpkeeperAgent",
+                        RoomUpkeeperAgent.class.getCanonicalName(),
                         new Object[]{getArguments()[0], getArguments()[1], room.getId(), room.getArea()}).start();
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/main/java/hvac/coordinator/CoordinatorAgent.java
+++ b/src/main/java/hvac/coordinator/CoordinatorAgent.java
@@ -5,10 +5,21 @@ import hvac.calendar.CalendarException;
 import hvac.calendar.CalendarWrapper;
 import hvac.coordinator.behaviours.MeetingUpdatingBehaviour;
 import hvac.database.Connection;
+import hvac.ontologies.meeting.MeetingOntology;
+import hvac.simulation.rooms.Room;
+import hvac.simulation.rooms.RoomLink;
+import hvac.simulation.rooms.RoomMap;
+import hvac.simulation.rooms.RoomWall;
 import hvac.util.df.DfHelpers;
-import jade.core.Agent;
+import jade.content.lang.sl.SLCodec;
+import jade.core.Runtime;
+import jade.core.*;
+import jade.wrapper.AgentContainer;
+
+import java.util.ArrayList;
 
 import static hvac.util.Helpers.initTimeFromArgs;
+import static hvac.util.Helpers.loadMap;
 
 @SuppressWarnings("unused")
 public class CoordinatorAgent extends Agent {
@@ -17,6 +28,9 @@ public class CoordinatorAgent extends Agent {
     CoordinatorContext context = new CoordinatorContext();
     @Override
     protected void setup() {
+        getContentManager().registerLanguage(new SLCodec());
+        getContentManager().registerOntology(MeetingOntology.getInstance());
+        context.getLogger().setAgentName("coordinator");
         if(!initTimeFromArgs(this, this::usage)) return;
         if(!DfHelpers.tryRegisterInDfWithServiceName(this, "coordinator")) return;
         database = new Connection();
@@ -29,7 +43,41 @@ public class CoordinatorAgent extends Agent {
             doDelete();
             return;
         }
+        deployAgents();
         this.addBehaviour(new MeetingUpdatingBehaviour(this, 1000, calendar, context));
+    }
+
+    private void deployAgents() {
+        RoomMap roomMap = new RoomMap();
+        loadMap(roomMap);
+
+        for (Room room : roomMap.getRooms()) {
+            Profile profile = new ProfileImpl();
+            profile.setParameter(Profile.MAIN_HOST, "localhost");
+            profile.setParameter(Profile.CONTAINER_NAME, Integer.toString(room.getId()));
+            AgentContainer newContainer = Runtime.instance().createAgentContainer(profile);
+            ArrayList<Integer> myNeighboursIds = new ArrayList<>();
+            ArrayList<RoomWall> myWalls = new ArrayList<>();
+            for (RoomLink roomLink : roomMap.getNeighbors(room)){
+                myNeighboursIds.add(roomLink.getNeighbor().getId());
+                myWalls.add(roomLink.getWall());
+            }
+            try {
+                newContainer.createNewAgent("room-coordinator-" + room.getId(),
+                        "hvac.roomcoordinator.RoomCoordinatorAgent",
+                        new Object[]{room.getId(), getAID(), myNeighboursIds, myWalls}).start();
+
+                newContainer.createNewAgent("upkeeper-" + room.getId(),
+                        "hvac.roomupkeeper.RoomUpkeeperAgent",
+                        new Object[]{getArguments()[0], getArguments()[1], room.getId(), room.getArea()}).start();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            context.addRoom(room.getSeats(),
+                    new AID("room-coordinator-" + room.getId() + "@" + newContainer.getPlatformName(),AID.ISGUID));
+        }
+
+        context.getLogger().log("Deployed all coordinators and upkeepers");
     }
 
     private void usage(String err) {

--- a/src/main/java/hvac/coordinator/CoordinatorContext.java
+++ b/src/main/java/hvac/coordinator/CoordinatorContext.java
@@ -1,10 +1,25 @@
 package hvac.coordinator;
 
+import hvac.util.Logger;
+import jade.core.AID;
+
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class CoordinatorContext {
-    private HashMap<String, Meeting> meetingsToAssign = new HashMap<>();
-    private HashMap<String, Meeting> assignedMeetings = new HashMap<>();
+    private final Map<Integer, Set<AID>> rooms = new HashMap<>();
+    private final HashMap<String, Meeting> meetingsToAssign = new HashMap<>();
+    private final HashMap<String, Meeting> assignedMeetings = new HashMap<>();
+    private final Logger logger = new Logger();
+
+    public void addRoom(int seats, AID roomAID){
+        if (! rooms.containsKey(seats)){
+            rooms.put(seats, new HashSet<>());
+        }
+        rooms.getOrDefault(seats,null).add(roomAID);
+    }
 
     public HashMap<String, Meeting> getMeetingsToAssign() {
         return meetingsToAssign;
@@ -12,5 +27,9 @@ public class CoordinatorContext {
 
     public HashMap<String, Meeting> getAssignedMeetings() {
         return assignedMeetings;
+    }
+
+    public Logger getLogger() {
+        return logger;
     }
 }

--- a/src/main/java/hvac/roomcoordinator/RoomContext.java
+++ b/src/main/java/hvac/roomcoordinator/RoomContext.java
@@ -2,6 +2,7 @@ package hvac.roomcoordinator;
 
 import hvac.ontologies.meeting.Meeting;
 import hvac.simulation.rooms.RoomWall;
+import hvac.util.Logger;
 import jade.core.AID;
 
 import java.util.*;
@@ -15,6 +16,7 @@ public class RoomContext {
     private Meeting currentMeeting;
     private final PriorityQueue<Meeting> meetingsQueue = new PriorityQueue<>();
     private final Map<String, AbstractMap.SimpleEntry<Meeting, Map<AID, Float>>> neighboursForecastStatus = new HashMap<>();
+    private final Logger logger = new Logger();
 
     RoomContext(int myRoomId, AID coordinator){
         this.myRoomId = myRoomId;
@@ -66,6 +68,10 @@ public class RoomContext {
             return null;
         }
         return meetingsQueue.peek();
+    }
+
+    public Logger getLogger() {
+        return logger;
     }
 
     public boolean isTimeSlotAvailable(Meeting meeting){

--- a/src/main/java/hvac/simulation/SimulationAgent.java
+++ b/src/main/java/hvac/simulation/SimulationAgent.java
@@ -1,5 +1,6 @@
 package hvac.simulation;
 
+import hvac.coordinator.CoordinatorAgent;
 import hvac.database.Connection;
 import hvac.ontologies.machinery.MachineryOntology;
 import hvac.ontologies.roomclimate.RoomClimateOntology;
@@ -15,6 +16,7 @@ import hvac.simulation.rooms.RoomClimate;
 import hvac.time.DateTimeSimulator;
 import hvac.util.df.DfHelpers;
 import hvac.weather.DatabaseForecastProvider;
+import hvac.weatherforecaster.WeatherForecasterAgent;
 import jade.content.lang.sl.SLCodec;
 import jade.core.Agent;
 import jade.domain.FIPANames;
@@ -35,11 +37,11 @@ public class SimulationAgent extends Agent {
         AgentContainer myContainer = getContainerController();
         try {
             myContainer.createNewAgent("coordinator",
-                    "hvac.coordinator.CoordinatorAgent",
+                    CoordinatorAgent.class.getCanonicalName(),
                     new Object[]{getArguments()[0], getArguments()[1]}).start();
 
             myContainer.createNewAgent("weather-forecaster",
-                    "hvac.weatherforecaster.WeatherForecasterAgent",
+                    WeatherForecasterAgent.class.getCanonicalName(),
                     new Object[]{getArguments()[0], getArguments()[1]}).start();
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/hvac/simulation/SimulationAgent.java
+++ b/src/main/java/hvac/simulation/SimulationAgent.java
@@ -18,6 +18,7 @@ import hvac.weather.DatabaseForecastProvider;
 import jade.content.lang.sl.SLCodec;
 import jade.core.Agent;
 import jade.domain.FIPANames;
+import jade.wrapper.AgentContainer;
 
 import static hvac.util.Helpers.initTimeFromArgs;
 import static hvac.util.Helpers.loadMap;
@@ -31,6 +32,19 @@ public class SimulationAgent extends Agent {
         if(!initTimeFromArgs(this, this::usage)) return;
         if(!DfHelpers.tryRegisterInDfWithServiceName(this, "simulation")) return;
         simulationContext.getLogger().setAgentName("simulation");
+        AgentContainer myContainer = getContainerController();
+        try {
+            myContainer.createNewAgent("coordinator",
+                    "hvac.coordinator.CoordinatorAgent",
+                    new Object[]{getArguments()[0], getArguments()[1]}).start();
+
+            myContainer.createNewAgent("weather-forecaster",
+                    "hvac.weatherforecaster.WeatherForecasterAgent",
+                    new Object[]{getArguments()[0], getArguments()[1]}).start();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        simulationContext.getLogger().log("Weather and Coordinator agents started.");
         getContentManager().registerLanguage(new SLCodec(),
                 FIPANames.ContentLanguage.FIPA_SL0);
         getContentManager().registerOntology(RoomClimateOntology.getInstance());

--- a/src/main/java/hvac/simulation/SimulationAgent.java
+++ b/src/main/java/hvac/simulation/SimulationAgent.java
@@ -12,7 +12,6 @@ import hvac.simulation.machinery.MachineParameter;
 import hvac.simulation.machinery.Ventilator;
 import hvac.simulation.rooms.Room;
 import hvac.simulation.rooms.RoomClimate;
-import hvac.simulation.rooms.RoomWall;
 import hvac.time.DateTimeSimulator;
 import hvac.util.df.DfHelpers;
 import hvac.weather.DatabaseForecastProvider;
@@ -21,6 +20,7 @@ import jade.core.Agent;
 import jade.domain.FIPANames;
 
 import static hvac.util.Helpers.initTimeFromArgs;
+import static hvac.util.Helpers.loadMap;
 
 @SuppressWarnings("unused")
 public class SimulationAgent extends Agent {
@@ -36,7 +36,7 @@ public class SimulationAgent extends Agent {
         getContentManager().registerOntology(RoomClimateOntology.getInstance());
         getContentManager().registerOntology(MachineryOntology.getInstance());
         connection = new Connection();
-        loadMap();
+        loadMap(simulationContext.getRoomMap());
         setDefaultClimate();
         addBehaviour(new ClimateUpdatingBehaviour(
                 this, 1000, simulationContext, DateTimeSimulator.getTimeScale(),
@@ -52,25 +52,6 @@ public class SimulationAgent extends Agent {
         System.err.println("timescale - floating point value indicating speed of passing time");
         System.err.println("Date from which to start simulating \"yyyy-MM-dd HH:mm:ss\"");
         System.err.println("err:" + err);
-    }
-
-    private void loadMap() {
-        Room r1 = new Room(1,200, 50);
-        Room r2 = new Room(2,250, 70);
-        Room r3 = new Room(3,150, 35);
-        Room r4 = new Room(4,300, 80);
-        RoomWall r12 = new RoomWall(24, 0.4f);
-        RoomWall r23 = new RoomWall(16, 0.2f);
-        RoomWall r34 = new RoomWall(18, 0.5f);
-        RoomWall r41 = new RoomWall(40, 0.1f);
-        simulationContext.getRoomMap().addRoom(r1);
-        simulationContext.getRoomMap().addRoom(r2);
-        simulationContext.getRoomMap().addRoom(r3);
-        simulationContext.getRoomMap().addRoom(r4);
-        simulationContext.getRoomMap().linkRooms(r1, r2, r12);
-        simulationContext.getRoomMap().linkRooms(r2, r3, r23);
-        simulationContext.getRoomMap().linkRooms(r3, r4, r34);
-        simulationContext.getRoomMap().linkRooms(r4, r1, r41);
     }
 
     private void setDefaultClimate() {

--- a/src/main/java/hvac/simulation/rooms/Room.java
+++ b/src/main/java/hvac/simulation/rooms/Room.java
@@ -2,17 +2,23 @@ package hvac.simulation.rooms;
 
 public class Room {
     private final int id;
+    private final int seats;
     private final float volume;//in m3
     private final float area;//in m2
-    public Room(int id, float volume, float area)
+    public Room(int id, int seats, float volume, float area)
     {
         this.id = id;
+        this.seats = seats;
         this.volume = volume;
         this.area = area;
     }
 
-    public int getId() { return id; }
-
+    public int getId() {
+        return id;
+    }
+    public int getSeats() {
+        return seats;
+    }
     public float getVolume() {
         return volume;
     }

--- a/src/main/java/hvac/util/Helpers.java
+++ b/src/main/java/hvac/util/Helpers.java
@@ -2,6 +2,9 @@ package hvac.util;
 
 import hvac.ontologies.machinery.Machinery;
 import hvac.ontologies.weather.WeatherSnapshot;
+import hvac.simulation.rooms.Room;
+import hvac.simulation.rooms.RoomMap;
+import hvac.simulation.rooms.RoomWall;
 import hvac.time.DateTimeSimulator;
 import jade.core.Agent;
 
@@ -14,6 +17,25 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 public class Helpers {
+    public static void loadMap(RoomMap roomMap){
+        Room r1 = new Room(1,2,200, 50);
+        Room r2 = new Room(2,2,250, 70);
+        Room r3 = new Room(3,3,150, 35);
+        Room r4 = new Room(4,3,300, 80);
+        RoomWall r12 = new RoomWall(24, 0.4f);
+        RoomWall r23 = new RoomWall(16, 0.2f);
+        RoomWall r34 = new RoomWall(18, 0.5f);
+        RoomWall r41 = new RoomWall(40, 0.1f);
+        roomMap.addRoom(r1);
+        roomMap.addRoom(r2);
+        roomMap.addRoom(r3);
+        roomMap.addRoom(r4);
+        roomMap.linkRooms(r1, r2, r12);
+        roomMap.linkRooms(r2, r3, r23);
+        roomMap.linkRooms(r3, r4, r34);
+        roomMap.linkRooms(r4, r1, r41);
+    }
+
     public static boolean isBetween(LocalDateTime date, LocalDateTime start, LocalDateTime end) {
         return date.isAfter(start) && date.isBefore(end);
     }


### PR DESCRIPTION
 Moved room's map loading to helper, as now two agents will use it - this will be also helpful once it will be no longer hardcoded (maybe against YAGNI, but I hope not). Now SimulationAgent starts both CoordinatorAgent and WeatherForecasterAgent with the same args, and then room coordinators and upkeepers are started by CoordinatorAgent. Added seats to the room info, as it will be needed for scheduling the meetings. Added logger to RoomCoordinatorAgent and CoordinatorAgent. README.md updated.

Currently Coordinator saves RoomCoordinators' AIDs, and it's the case of not using DF (but IMO understandable, as it's created as mentioned here: https://jade.tilab.com/doc/api/jade/core/AID.html#AID-java.lang.String-boolean-). The second should be completely safe (coordinator passes his AID as argument to Room Coordinators).