### PR TITLE
Roomupkeeper - receiving conditions to mantain from room coordinator

### DIFF
--- a/src/main/java/hvac/coordinator/CoordinatorAgent.java
+++ b/src/main/java/hvac/coordinator/CoordinatorAgent.java
@@ -67,7 +67,7 @@ public class CoordinatorAgent extends Agent {
             try {
                 newContainer.createNewAgent("room-coordinator-" + room.getId(),
                         RoomCoordinatorAgent.class.getCanonicalName(),
-                        new Object[]{room.getId(), getAID(), myNeighboursIds, myWalls}).start();
+                        new Object[]{getArguments()[0], getArguments()[1], room.getId(), getAID(), myNeighboursIds, myWalls}).start();
 
                 newContainer.createNewAgent("upkeeper-" + room.getId(),
                         RoomUpkeeperAgent.class.getCanonicalName(),

--- a/src/main/java/hvac/ontologies/meeting/MantainConditions.java
+++ b/src/main/java/hvac/ontologies/meeting/MantainConditions.java
@@ -1,0 +1,25 @@
+package hvac.ontologies.meeting;
+
+import jade.content.AgentAction;
+import jade.util.leap.ArrayList;
+import jade.util.leap.List;
+
+public class MantainConditions implements AgentAction {
+    private List conditions;
+
+    public MantainConditions() {
+        conditions = new ArrayList();
+    }
+
+    public MantainConditions(List conditions) {
+        this.conditions = conditions;
+    }
+
+    public List getConditions() {
+        return conditions;
+    }
+
+    public void setConditions(List conditions) {
+        this.conditions = conditions;
+    }
+}

--- a/src/main/java/hvac/ontologies/meeting/Meeting.java
+++ b/src/main/java/hvac/ontologies/meeting/Meeting.java
@@ -4,6 +4,7 @@ import jade.content.Concept;
 
 import java.util.Date;
 
+@SuppressWarnings("unused")
 public class Meeting implements Concept, Comparable<Meeting> {
     private String meetingID;
     private Date startDate;
@@ -11,12 +12,26 @@ public class Meeting implements Concept, Comparable<Meeting> {
     private int peopleInRoom;
     private float temperature;
 
+    public Meeting() {}
+
     public Meeting(String meetingID, Date startDate, Date endDate, int peopleInRoom, float temperature) {
         this.meetingID = meetingID;
         this.startDate = startDate;
         this.endDate = endDate;
         this.peopleInRoom = peopleInRoom;
         this.temperature = temperature;
+    }
+
+    public void setMeetingID(String meetingID) {
+        this.meetingID = meetingID;
+    }
+
+    public void setStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+    public void setPeopleInRoom(int peopleInRoom) {
+        this.peopleInRoom = peopleInRoom;
     }
 
     public String getMeetingID() {
@@ -35,7 +50,6 @@ public class Meeting implements Concept, Comparable<Meeting> {
         this.endDate = endDate;
     }
 
-    @SuppressWarnings("unused")
     public int getPeopleInRoom() {
         return peopleInRoom;
     }
@@ -62,5 +76,16 @@ public class Meeting implements Concept, Comparable<Meeting> {
     @Override
     public int compareTo(Meeting emp) {
         return this.getStartDate().compareTo(emp.getStartDate());
+    }
+
+    @Override
+    public String toString() {
+        return "Meeting{" +
+                "meetingID='" + meetingID + '\'' +
+                ", startDate=" + startDate +
+                ", endDate=" + endDate +
+                ", peopleInRoom=" + peopleInRoom +
+                ", temperature=" + temperature +
+                '}';
     }
 }

--- a/src/main/java/hvac/ontologies/meeting/MeetingOntology.java
+++ b/src/main/java/hvac/ontologies/meeting/MeetingOntology.java
@@ -4,6 +4,7 @@ import jade.content.onto.BasicOntology;
 import jade.content.onto.Ontology;
 import jade.content.schema.AgentActionSchema;
 import jade.content.schema.ConceptSchema;
+import jade.content.schema.ObjectSchema;
 import jade.content.schema.PrimitiveSchema;
 
 public class MeetingOntology extends Ontology {
@@ -20,6 +21,9 @@ public class MeetingOntology extends Ontology {
     public static final String REQUEST = "request";
     public static final String REQUEST_MEETING = "meeting";
     public static final String REQUEST_STATUS = "status";
+
+    public static final String MANTAIN_CONDITIONS = "MantainConditions";
+    public static final String MANTAIN_CONDITIONS_CONDITIONS = "conditions";
 
     private static Ontology theInstance = new MeetingOntology();
 
@@ -41,8 +45,13 @@ public class MeetingOntology extends Ontology {
 
             AgentActionSchema as = new AgentActionSchema(REQUEST);
             add(as, Request.class);
-            cs.add(REQUEST_MEETING, (ConceptSchema) getSchema(MEETING));
-            cs.add(REQUEST_STATUS, (ConceptSchema) getSchema(REQUEST_STATUS));
+            as.add(REQUEST_MEETING, (ConceptSchema) getSchema(MEETING));
+            as.add(REQUEST_STATUS, (ConceptSchema) getSchema(REQUEST_STATUS));
+
+            as = new AgentActionSchema(MANTAIN_CONDITIONS);
+            add(as, MantainConditions.class);
+            as.add(MANTAIN_CONDITIONS_CONDITIONS, (ConceptSchema)getSchema(MEETING),
+                    0, ObjectSchema.UNLIMITED);
         }
         catch (Exception oe) {oe.printStackTrace();}
     }

--- a/src/main/java/hvac/ontologies/meeting/Request.java
+++ b/src/main/java/hvac/ontologies/meeting/Request.java
@@ -2,10 +2,12 @@ package hvac.ontologies.meeting;
 
 import jade.content.AgentAction;
 
+@SuppressWarnings("unused")
 public class Request implements AgentAction {
     private Meeting meeting;
     private RequestStatus status;
 
+    public Request(){}
     public Request(Meeting meeting, RequestStatus status) {
         this.meeting = meeting;
         this.status = status;
@@ -15,11 +17,10 @@ public class Request implements AgentAction {
         return meeting;
     }
 
-//    public void setMeeting(Meeting meeting) {
-//        this.meeting = meeting;
-//    }
+    public void setMeeting(Meeting meeting) {
+        this.meeting = meeting;
+    }
 
-    @SuppressWarnings("unused")
     public RequestStatus getStatus() {
         return status;
     }

--- a/src/main/java/hvac/ontologies/weather/Forecast.java
+++ b/src/main/java/hvac/ontologies/weather/Forecast.java
@@ -1,6 +1,7 @@
 package hvac.ontologies.weather;
 
 import jade.content.Predicate;
+import jade.util.leap.ArrayList;
 import jade.util.leap.List;
 
 //forecast is a predicate because one can say weather will be like this in this time period - it is a true/false statement
@@ -8,12 +9,17 @@ public class Forecast implements Predicate {
     private List weatherSnapshots;
 
 
-    public Forecast() {}
+    public Forecast() {
+        weatherSnapshots = new ArrayList();
+    }
+
     public Forecast(List weatherSnapshots) {
         this.weatherSnapshots = weatherSnapshots;
     }
 
-    public jade.util.leap.List getWeatherSnapshots() {return weatherSnapshots;}
+    public jade.util.leap.List getWeatherSnapshots() {
+        return weatherSnapshots;
+    }
 
     public void setWeatherSnapshots(List weatherSnapshots) {
         this.weatherSnapshots = weatherSnapshots;

--- a/src/main/java/hvac/roomcoordinator/RoomContext.java
+++ b/src/main/java/hvac/roomcoordinator/RoomContext.java
@@ -2,9 +2,11 @@ package hvac.roomcoordinator;
 
 import hvac.ontologies.meeting.Meeting;
 import hvac.simulation.rooms.RoomWall;
+import hvac.util.Conversions;
 import hvac.util.Logger;
 import jade.core.AID;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 public class RoomContext {
@@ -13,7 +15,6 @@ public class RoomContext {
     private final AID coordinator;
     private AID myRoomUpkeeper;
     private final HashMap<AID, RoomWall> myNeighbours = new HashMap<>();
-    private Meeting currentMeeting;
     private final PriorityQueue<Meeting> meetingsQueue = new PriorityQueue<>();
     private final Map<String, AbstractMap.SimpleEntry<Meeting, Map<AID, Float>>> neighboursForecastStatus = new HashMap<>();
     private final Logger logger = new Logger();
@@ -47,27 +48,18 @@ public class RoomContext {
         myNeighbours.put(key, value);
     }
 
-    public Meeting getCurrentMeeting() {
-        return currentMeeting;
-    }
-
-    public void setCurrentMeeting(Meeting currentMeeting) {
-        this.currentMeeting = currentMeeting;
-    }
-
     public void addMeeting(Meeting meeting){
         meetingsQueue.add(meeting);
     }
 
-    public Meeting peekMeeting(){
-        return meetingsQueue.peek();
-    }
-
-    public Meeting checkMeetings(Date date){
-        if (meetingsQueue.isEmpty() || 0 < meetingsQueue.peek().getStartDate().compareTo(date)){
-            return null;
+    public List<Meeting> getMeetingsStartingBefore(LocalDateTime date){
+        List<Meeting> result = new ArrayList<>();
+        for (Meeting meeting : meetingsQueue) {
+            if (Conversions.toLocalDateTime(meeting.getStartDate()).isAfter(date))
+                break;
+            result.add(meeting);
         }
-        return meetingsQueue.peek();
+        return result;
     }
 
     public Logger getLogger() {
@@ -93,9 +85,6 @@ public class RoomContext {
     }
 
     public void removeMeeting(String ID){
-        if (null != getCurrentMeeting() && ID.equals(getCurrentMeeting().getMeetingID())){
-            currentMeeting.setEndDate(new Date(Long.MIN_VALUE));
-        }
         for (Meeting meeting:meetingsQueue){
             if (meeting.getMeetingID().equals(ID)){
                 meetingsQueue.remove(meeting);

--- a/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
+++ b/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
@@ -12,6 +12,8 @@ import jade.core.Agent;
 
 import java.util.ArrayList;
 
+import static hvac.util.Helpers.initTimeFromArgs;
+
 @SuppressWarnings("unused")
 public class RoomCoordinatorAgent extends Agent {
     private RoomContext roomContext;
@@ -21,6 +23,7 @@ public class RoomCoordinatorAgent extends Agent {
 
     @Override
     protected void setup() {
+        if(!initTimeFromArgs(this, this::usage)) return;
         getContentManager().registerLanguage(new SLCodec());
         getContentManager().registerOntology(MeetingOntology.getInstance());
         roomContext = getContext();
@@ -33,7 +36,7 @@ public class RoomCoordinatorAgent extends Agent {
     private RoomContext getContext() {
         int myRoomId;
         try {
-            myRoomId = Integer.parseInt(getArguments()[0].toString());
+            myRoomId = Integer.parseInt(getArguments()[2].toString());
         } catch (NumberFormatException e) {
             usage("room Id is not valid");
             return null;
@@ -42,16 +45,16 @@ public class RoomCoordinatorAgent extends Agent {
             usage("room cannot be registered in DF");
             return null;
         }
-        RoomContext newRoomContext = new RoomContext(myRoomId, (AID) getArguments()[1]);
+        RoomContext newRoomContext = new RoomContext(myRoomId, (AID) getArguments()[3]);
         newRoomContext.getLogger().setAgentName("room coordinator (" + newRoomContext.getMyRoomId() + ")");
         try {
-            Ids = (ArrayList<Integer>) getArguments()[2];
+            Ids = (ArrayList<Integer>) getArguments()[4];
         } catch (Exception e) {
             usage("room ids list is not valid");
             return null;
         }
         try {
-            RoomWalls = (ArrayList<RoomWall>) getArguments()[3];
+            RoomWalls = (ArrayList<RoomWall>) getArguments()[5];
         } catch (Exception e) {
             usage("room neighbour list is not valid");
             return null;
@@ -83,6 +86,8 @@ public class RoomCoordinatorAgent extends Agent {
     private void usage(String err) {
         System.err.println("-------- Room Coordinator agent usage --------------");
         System.err.println("simulation:hvac.roomcoordinator.RoomCoordinatorAgent(RoomId, CoordinatorAID, NeighboursIds, RoomWalls)");
+        System.err.println("timescale - floating point value indicating speed of passing time");
+        System.err.println("Date from which to start simulating \"yyyy-MM-dd HH:mm:ss\"");
         System.err.println("RoomId - integer uniquely identifying the room of this agent");
         System.err.println("CoordinatorAID - AID of Coordinator");
         System.err.println("NeighboursIds - array of neighbours' Ids");

--- a/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
+++ b/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
@@ -9,12 +9,12 @@ import hvac.util.df.FindingBehaviour;
 import jade.content.lang.sl.SLCodec;
 import jade.core.AID;
 import jade.core.Agent;
+import jade.domain.FIPANames;
 
 import java.util.ArrayList;
 
 import static hvac.util.Helpers.initTimeFromArgs;
 
-@SuppressWarnings("unused")
 public class RoomCoordinatorAgent extends Agent {
     private RoomContext roomContext;
     private ArrayList<Integer> Ids;
@@ -24,7 +24,8 @@ public class RoomCoordinatorAgent extends Agent {
     @Override
     protected void setup() {
         if(!initTimeFromArgs(this, this::usage)) return;
-        getContentManager().registerLanguage(new SLCodec());
+        getContentManager().registerLanguage(new SLCodec(),
+                FIPANames.ContentLanguage.FIPA_SL0);
         getContentManager().registerOntology(MeetingOntology.getInstance());
         roomContext = getContext();
         if(roomContext == null) {
@@ -63,7 +64,9 @@ public class RoomCoordinatorAgent extends Agent {
                 upkeeperDescriptor->{
                     newRoomContext.setMyRoomUpkeeper(upkeeperDescriptor.getName());
                     processRoom();}));
-
+        //uncomment this to test coordinator-upkeeper communication
+        //if(myRoomId == 1) newRoomContext.addMeeting(new Meeting("abc", Conversions.toDate(DateTimeSimulator.getCurrentDate().plusMinutes(40)),
+        //        Conversions.toDate(DateTimeSimulator.getCurrentDate().plusHours(3)),3, 300.0f));
         return newRoomContext;
     }
 

--- a/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorCyclicBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorCyclicBehaviour.java
@@ -7,20 +7,25 @@ import jade.core.AID;
 import jade.core.Agent;
 import jade.core.behaviours.CyclicBehaviour;
 import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
 
 public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
     private final RoomContext roomContext;
     private final RoomCoordinatorTickerBehaviour tickerBehaviour;
+    private final MessageTemplate messageTemplate;
 
     public RoomCoordinatorCyclicBehaviour(Agent a, RoomContext roomContext, RoomCoordinatorTickerBehaviour tickerBehaviour) {
         super(a);
         this.roomContext = roomContext;
         this.tickerBehaviour = tickerBehaviour;
+        messageTemplate = MessageTemplate.not(MessageTemplate.MatchSender(
+                roomContext.getMyRoomUpkeeper()
+        ));
     }
 
     @Override
     public void action() {
-        ACLMessage msg = myAgent.receive();
+        ACLMessage msg = myAgent.receive(messageTemplate);
         if (msg != null) {
             handleMessage(msg);
         }
@@ -126,7 +131,7 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
             request.setStatus(RequestStatus.FAILED);
         }
         fillAndSend(reply, request);
-        tickerBehaviour.reset(0);
+        tickerBehaviour.reset(1);
     }
 
     private void handleCancel(ACLMessage msg){
@@ -139,7 +144,7 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         reply.setPerformative(ACLMessage.CONFIRM);
         request.setStatus(RequestStatus.CANCELLED);
         fillAndSend(reply, request);
-        tickerBehaviour.reset(0);
+        tickerBehaviour.reset(1);
     }
 
     private void notUnderstood(ACLMessage msg){

--- a/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorTickerBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorTickerBehaviour.java
@@ -58,10 +58,12 @@ public class RoomCoordinatorTickerBehaviour extends TickerBehaviour {
                 myAgent.send(msg);
                 step = Step.AWAITING_UPKEEPER_RESPONSE;
                 pendingMeetingsInUpkeeper = incomingMeetings;
-                reset(0);
+                reset(1);
             } catch (Codec.CodecException | OntologyException e) {
                 e.printStackTrace();
             }
+        } else {
+            reset(standardPeriod);
         }
     }
 

--- a/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorTickerBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/RoomCoordinatorTickerBehaviour.java
@@ -1,73 +1,88 @@
 package hvac.roomcoordinator.behaviours;
 
+import com.google.common.base.Joiner;
 import hvac.ontologies.meeting.Meeting;
-import hvac.ontologies.meeting.MeetingOntology;
-import hvac.ontologies.meeting.Request;
-import hvac.ontologies.meeting.RequestStatus;
 import hvac.roomcoordinator.RoomContext;
-import jade.content.lang.sl.SLCodec;
+import hvac.roomupkeeper.RoomUpkeeperAgentMessenger;
+import hvac.time.DateTimeSimulator;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
 import jade.core.Agent;
 import jade.core.behaviours.TickerBehaviour;
 import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
 
-import java.util.Date;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class RoomCoordinatorTickerBehaviour extends TickerBehaviour {
     private final RoomContext roomContext;
+    private List<Meeting> pendingMeetingsInUpkeeper = new ArrayList<>();
+    private List<Meeting> meetingsInUpkeeper = new ArrayList<>();
+    private final MessageTemplate upkeeperTemplate;
+    private final long standardPeriod;
+    private Step step = Step.CHECKING_MEETING_CHANGES;
+    private enum Step {
+        CHECKING_MEETING_CHANGES,
+        AWAITING_UPKEEPER_RESPONSE
+    }
 
     public RoomCoordinatorTickerBehaviour(Agent a, long period, RoomContext roomContext) {
         super(a, period);
         this.roomContext = roomContext;
+        upkeeperTemplate = MessageTemplate.MatchSender(roomContext.getMyRoomUpkeeper());
+        standardPeriod = period;
     }
 
     @Override
     protected void onTick() {
-        if (null == roomContext.getCurrentMeeting()){
-            Meeting meeting = roomContext.checkMeetings(new Date());
-            if (null != meeting){
-                roomContext.setCurrentMeeting(meeting);
-                ACLMessage msg = new ACLMessage(ACLMessage.INFORM);
-                Request request = new Request(roomContext.getCurrentMeeting(), RequestStatus.EXECUTE);
-                sendUpdateToUpkeeper(msg, request);
-                this.reset(meeting.getEndDate().getTime() - new Date().getTime());
-            }
-            else{
-                if (null != roomContext.peekMeeting()){
-                    this.reset(roomContext.peekMeeting().getStartDate().getTime() - new Date().getTime());
-                }
-                else{
-                    this.reset(Long.MAX_VALUE);
-                }
-            }
+        switch (step) {
+
+            case CHECKING_MEETING_CHANGES:
+                checkMeetingChanges();
+                break;
+            case AWAITING_UPKEEPER_RESPONSE:
+                awaitUpkeeperResponse();
+                break;
         }
-        else{
-            if (roomContext.getCurrentMeeting().getEndDate().before(new Date())){
-                Meeting currentMeeting = roomContext.getCurrentMeeting();
-                ACLMessage msg = new ACLMessage(ACLMessage.INFORM);
-                Request request = new Request(currentMeeting, RequestStatus.FINISHED);
-                sendUpdateToUpkeeper(msg, request);
-                roomContext.setCurrentMeeting(null);
-                roomContext.removeMeeting(currentMeeting.getMeetingID());
-                this.reset(0);
-            }
-            else{
-                this.reset(1000);
+
+    }
+
+    private void checkMeetingChanges() {
+        List<Meeting> incomingMeetings =
+                roomContext.getMeetingsStartingBefore(DateTimeSimulator.getCurrentDate().plusMinutes(30));
+        if(!meetingsInUpkeeper.equals(incomingMeetings)) {
+            try {
+                ACLMessage msg = RoomUpkeeperAgentMessenger.prepareMantainConditions(incomingMeetings, myAgent, roomContext.getMyRoomUpkeeper());
+                myAgent.send(msg);
+                step = Step.AWAITING_UPKEEPER_RESPONSE;
+                pendingMeetingsInUpkeeper = incomingMeetings;
+                reset(0);
+            } catch (Codec.CodecException | OntologyException e) {
+                e.printStackTrace();
             }
         }
     }
 
-    private void fillAndSend(ACLMessage msg, Request request){
-        try {
-            myAgent.getContentManager().fillContent(msg, request);
-        } catch (Exception e){e.printStackTrace();}
-        myAgent.send(msg);
-    }
-
-    private void sendUpdateToUpkeeper(ACLMessage msg, Request request){
-        msg.setConversationId(roomContext.getCurrentMeeting().getMeetingID());
-        msg.setLanguage(new SLCodec().getName());
-        msg.setOntology(MeetingOntology.getInstance().getName());
-        msg.addReceiver(roomContext.getMyRoomUpkeeper());
-        fillAndSend(msg, request);
+    private void awaitUpkeeperResponse() {
+        ACLMessage msg = myAgent.receive(upkeeperTemplate);
+        if(msg != null) {
+            if (msg.getPerformative() == ACLMessage.AGREE) {
+                meetingsInUpkeeper = pendingMeetingsInUpkeeper;
+            } else {
+                roomContext.getLogger().log("upkeeper hasn't started maintaining conditions, conditions: "
+                + Joiner.on(",").join(pendingMeetingsInUpkeeper.stream().map(meeting->
+                    "startDate="+meeting.getStartDate()+
+                            ", endDate="+meeting.getEndDate()+
+                            ", people"+meeting.getPeopleInRoom()+
+                            ", meetingId"+meeting.getMeetingID()+
+                            ", temperature"+meeting.getTemperature())
+                        .collect(Collectors.toList())
+                ));
+            }
+            step = Step.CHECKING_MEETING_CHANGES;
+            reset(standardPeriod);
+        }
     }
 }

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgent.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgent.java
@@ -5,6 +5,7 @@ import hvac.ontologies.meeting.MeetingOntology;
 import hvac.ontologies.roomclimate.RoomClimateOntology;
 import hvac.ontologies.weather.WeatherOntology;
 import hvac.roomupkeeper.behaviours.ClimateUpkeepingBehaviour;
+import hvac.roomupkeeper.behaviours.ConditionsReceivingBehaviour;
 import hvac.util.df.DfHelpers;
 import hvac.util.df.FindingBehaviour;
 import jade.content.lang.sl.SLCodec;
@@ -40,6 +41,7 @@ public class RoomUpkeeperAgent extends Agent {
                 context.setWeatherForecaster(forecasterDescriptor.getName());
                 context.getLogger().setAgentName("room upkeeper (" + context.getMyRoomId() + ")");
                 addBehaviour(new ClimateUpkeepingBehaviour(this, context));
+                addBehaviour(new ConditionsReceivingBehaviour(this, context));
             }));
         }));
     }

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgent.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgent.java
@@ -1,12 +1,10 @@
 package hvac.roomupkeeper;
 
 import hvac.ontologies.machinery.MachineryOntology;
-import hvac.ontologies.meeting.Meeting;
+import hvac.ontologies.meeting.MeetingOntology;
 import hvac.ontologies.roomclimate.RoomClimateOntology;
 import hvac.ontologies.weather.WeatherOntology;
 import hvac.roomupkeeper.behaviours.ClimateUpkeepingBehaviour;
-import hvac.time.DateTimeSimulator;
-import hvac.util.Conversions;
 import hvac.util.df.DfHelpers;
 import hvac.util.df.FindingBehaviour;
 import jade.content.lang.sl.SLCodec;
@@ -15,7 +13,6 @@ import jade.domain.FIPANames;
 
 import static hvac.util.Helpers.initTimeFromArgs;
 
-@SuppressWarnings("unused")
 public class RoomUpkeeperAgent extends Agent {
     @Override
     protected void setup() {
@@ -26,6 +23,7 @@ public class RoomUpkeeperAgent extends Agent {
         getContentManager().registerOntology(RoomClimateOntology.getInstance());
         getContentManager().registerOntology(MachineryOntology.getInstance());
         getContentManager().registerOntology(WeatherOntology.getInstance());
+        getContentManager().registerOntology(MeetingOntology.getInstance());
 
         RoomUpkeeperContext context = getContext();
         if(context == null) {
@@ -42,12 +40,6 @@ public class RoomUpkeeperAgent extends Agent {
                 context.setWeatherForecaster(forecasterDescriptor.getName());
                 context.getLogger().setAgentName("room upkeeper (" + context.getMyRoomId() + ")");
                 addBehaviour(new ClimateUpkeepingBehaviour(this, context));
-                context.setNextMeeting(new Meeting(
-                        "abc",
-                        Conversions.toDate(DateTimeSimulator.getCurrentDate().plusHours(2)),
-                        Conversions.toDate(DateTimeSimulator.getCurrentDate().plusHours(4)),
-                        5,
-                        300.0f));
             }));
         }));
     }

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgentMessenger.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgentMessenger.java
@@ -1,0 +1,38 @@
+package hvac.roomupkeeper;
+
+import hvac.ontologies.meeting.MantainConditions;
+import hvac.ontologies.meeting.Meeting;
+import hvac.ontologies.roomclimate.RoomClimateOntology;
+import hvac.util.Conversions;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
+import jade.core.AID;
+import jade.core.Agent;
+import jade.lang.acl.ACLMessage;
+
+import java.util.List;
+
+import static hvac.util.CommonMessengerFunctions.createActionMessage;
+
+/**
+ * class for use in agents that want communicate with room upkeeper agent
+ */
+public class RoomUpkeeperAgentMessenger {
+    /**
+     * prepares message that when sent to room upkeeper agent will make him update his conditions
+     * or refuse if periods in which to maintain conditions are not mutually exclusive
+     * Requires that agent has registered sl0 language and meeting ontology
+     * @param conditions list of conditions to mantain by upkeeper - they are meeting objects
+     * which contain conditions to mantain and dates between which they are mantained
+     * @param myAgent agent that will send the message
+     * @param roomUpkeeperAgent room upkeeper agent to which message will be sent
+     * @return prepared message
+     * @throws Codec.CodecException language fipa-sl0 is not registered
+     * @throws OntologyException meeting ontology is not registered
+     */
+    public static ACLMessage prepareMantainConditions(List<Meeting> conditions, Agent myAgent, AID roomUpkeeperAgent)
+            throws Codec.CodecException, OntologyException {
+        MantainConditions mantainConditions = new MantainConditions(Conversions.toJadeList(conditions));
+        return createActionMessage(myAgent, roomUpkeeperAgent, mantainConditions, RoomClimateOntology.getInstance());
+    }
+}

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgentMessenger.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperAgentMessenger.java
@@ -2,7 +2,7 @@ package hvac.roomupkeeper;
 
 import hvac.ontologies.meeting.MantainConditions;
 import hvac.ontologies.meeting.Meeting;
-import hvac.ontologies.roomclimate.RoomClimateOntology;
+import hvac.ontologies.meeting.MeetingOntology;
 import hvac.util.Conversions;
 import jade.content.lang.Codec;
 import jade.content.onto.OntologyException;
@@ -33,6 +33,6 @@ public class RoomUpkeeperAgentMessenger {
     public static ACLMessage prepareMantainConditions(List<Meeting> conditions, Agent myAgent, AID roomUpkeeperAgent)
             throws Codec.CodecException, OntologyException {
         MantainConditions mantainConditions = new MantainConditions(Conversions.toJadeList(conditions));
-        return createActionMessage(myAgent, roomUpkeeperAgent, mantainConditions, RoomClimateOntology.getInstance());
+        return createActionMessage(myAgent, roomUpkeeperAgent, mantainConditions, MeetingOntology.getInstance());
     }
 }

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
@@ -47,7 +47,7 @@ public class RoomUpkeeperContext {
     public void removeCompleteMeetings() {
         while(meetingQueue.peek() != null
                 && Conversions.toLocalDateTime(meetingQueue.peek().getEndDate())
-                .isAfter(DateTimeSimulator.getCurrentDate())) {
+                .isBefore(DateTimeSimulator.getCurrentDate())) {
             meetingQueue.remove();
         }
     }

--- a/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
+++ b/src/main/java/hvac/roomupkeeper/RoomUpkeeperContext.java
@@ -1,20 +1,23 @@
 package hvac.roomupkeeper;
 
 import hvac.ontologies.meeting.Meeting;
+import hvac.time.DateTimeSimulator;
+import hvac.util.Conversions;
 import hvac.util.Logger;
 import jade.core.AID;
+
+import java.util.ArrayDeque;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Queue;
+import java.util.stream.Collectors;
 
 public class RoomUpkeeperContext {
     private AID weatherForecaster;
     private AID simulationAgent;
     private final int myRoomId;
 
-    /**
-     * Next meeting that will be held in this room
-     * room will be accomodated to its required conditions
-     * is null if no new meeting is scheduled
-     */
-    private Meeting nextMeeting;
+    private Queue<Meeting> meetingQueue;
     private static final float relativeHumidityToMaintain = 0.5f;
     private final float myRoomArea;
 
@@ -25,15 +28,34 @@ public class RoomUpkeeperContext {
     public RoomUpkeeperContext(int myRoomId, float myRoomArea) {
         this.myRoomId = myRoomId;
         this.myRoomArea = myRoomArea;
-        this.nextMeeting = null;
+        this.meetingQueue = new ArrayDeque<>();
     }
 
+
+    /**
+     * Next meeting that will be held in this room
+     * room will be accomodated to its required conditions
+     * is null if no new meeting is scheduled
+     */
     public Meeting getNextMeeting() {
-        return nextMeeting;
+        return meetingQueue.peek();
     }
 
-    public void setNextMeeting(Meeting nextMeeting) {
-        this.nextMeeting = nextMeeting;
+    /**
+     * Removes all meetings for which end date is in the past
+     */
+    public void removeCompleteMeetings() {
+        while(meetingQueue.peek() != null
+                && Conversions.toLocalDateTime(meetingQueue.peek().getEndDate())
+                .isAfter(DateTimeSimulator.getCurrentDate())) {
+            meetingQueue.remove();
+        }
+    }
+
+    public void setMeetingQueue(List<Meeting> meetings) {
+        meetingQueue = meetings.stream()
+                .sorted(Comparator.comparing(Meeting::getStartDate))
+                .collect(Collectors.toCollection(ArrayDeque::new));
     }
 
     public AID getWeatherForecaster() {
@@ -53,7 +75,7 @@ public class RoomUpkeeperContext {
     }
 
     public float getRequiredVentilation() {
-        return (nextMeeting != null ? perPersonRequiredVentilation*nextMeeting.getPeopleInRoom() : 0.0f)
+        return (getNextMeeting() != null ? perPersonRequiredVentilation*getNextMeeting().getPeopleInRoom() : 0.0f)
                 + perM2RequiredVentilation * myRoomArea;
     }
 

--- a/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
+++ b/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
@@ -62,11 +62,7 @@ public class ClimateUpkeepingBehaviour extends CyclicBehaviour {
         //remove expired statuses, so only recent data is used in interpolation
         roomStatuses.removeIf(status -> status.getTime()
                 .isBefore(DateTimeSimulator.getCurrentDate().minusSeconds(CLIMATE_FORGET_TIME_SECONDS)));
-        //current meeting is over - delete it
-        if (context.getNextMeeting() != null && Conversions.toLocalDateTime(context.getNextMeeting().getEndDate())
-                .isBefore(DateTimeSimulator.getCurrentDate())) {
-            context.setNextMeeting(null);
-        }
+        context.removeCompleteMeetings();
         switch (step) {
             case INIT:
                 initStep();

--- a/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
+++ b/src/main/java/hvac/roomupkeeper/behaviours/ClimateUpkeepingBehaviour.java
@@ -83,7 +83,7 @@ public class ClimateUpkeepingBehaviour extends CyclicBehaviour {
 
     private void initStep() {
         if (context.getNextMeeting() == null) {
-            block();
+            block(1000);
             return;
         }
         decideNextStep();

--- a/src/main/java/hvac/roomupkeeper/behaviours/ConditionsReceivingBehaviour.java
+++ b/src/main/java/hvac/roomupkeeper/behaviours/ConditionsReceivingBehaviour.java
@@ -1,0 +1,85 @@
+package hvac.roomupkeeper.behaviours;
+
+import hvac.ontologies.meeting.MantainConditions;
+import hvac.ontologies.meeting.Meeting;
+import hvac.ontologies.meeting.MeetingOntology;
+import hvac.roomupkeeper.RoomUpkeeperContext;
+import hvac.util.Conversions;
+import jade.content.Concept;
+import jade.content.ContentElement;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
+import jade.content.onto.basic.Action;
+import jade.core.Agent;
+import jade.core.behaviours.CyclicBehaviour;
+import jade.domain.FIPANames;
+import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class ConditionsReceivingBehaviour extends CyclicBehaviour {
+    private final RoomUpkeeperContext context;
+    private final MessageTemplate messageTemplate = MessageTemplate.and(
+            MessageTemplate.MatchOntology(MeetingOntology.getInstance().getName()),
+            MessageTemplate.MatchLanguage(FIPANames.ContentLanguage.FIPA_SL0)
+    );
+
+    public ConditionsReceivingBehaviour(Agent a, RoomUpkeeperContext context) {
+        super(a);
+        this.context = context;
+    }
+
+    @Override
+    public void action() {
+        ACLMessage msg = myAgent.receive(messageTemplate);
+        if(msg != null) {
+            if(msg.getPerformative() == ACLMessage.REQUEST) {
+                try {
+                    processRequest(msg);
+                } catch (Codec.CodecException | OntologyException e) {
+                    replyNotUnderstood(msg);
+                }
+            } else {
+                replyNotUnderstood(msg);
+            }
+        } else {
+            block();
+        }
+    }
+
+    private void processRequest(ACLMessage msg) throws Codec.CodecException, OntologyException {
+        ContentElement ce = myAgent.getContentManager().extractContent(msg);
+        if (ce instanceof Action) {
+            Concept action = ((Action) ce).getAction();
+            if (action instanceof MantainConditions) {
+                MantainConditions mantainConditions = (MantainConditions)action;
+                List<Meeting> conditions = Conversions.toJavaList(mantainConditions.getConditions());
+                conditions.sort(Comparator.comparing(Meeting::getStartDate));
+                for(int i = 0; i <conditions.size()-1; i++) {
+                    if(Conversions.toLocalDateTime(conditions.get(i).getEndDate())
+                            .isAfter(Conversions.toLocalDateTime(conditions.get(i+1).getStartDate()))) {
+                        replyRefuse(msg);
+                        return;
+                    }
+                }
+                context.setMeetingQueue(conditions);
+                return;
+            }
+        }
+        replyNotUnderstood(msg);
+    }
+
+    private void replyRefuse(ACLMessage msg) {
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.REFUSE);
+        myAgent.send(reply);
+    }
+
+    private void replyNotUnderstood(ACLMessage msg) {
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.NOT_UNDERSTOOD);
+        myAgent.send(reply);
+    }
+}

--- a/src/main/java/hvac/simulation/SimulationAgentMessenger.java
+++ b/src/main/java/hvac/simulation/SimulationAgentMessenger.java
@@ -6,20 +6,18 @@ import hvac.ontologies.roomclimate.RoomClimate;
 import hvac.ontologies.roomclimate.RoomClimateOntology;
 import jade.content.ContentElement;
 import jade.content.lang.Codec;
-import jade.content.onto.Ontology;
 import jade.content.onto.OntologyException;
-import jade.content.onto.basic.Action;
 import jade.core.AID;
 import jade.core.Agent;
-import jade.domain.FIPANames;
 import jade.lang.acl.ACLMessage;
 
 import java.util.Optional;
 
+import static hvac.util.CommonMessengerFunctions.createActionMessage;
+
 /**
  * class for use in agents that want communicate with simulation agent
  */
-@SuppressWarnings("unused")
 public class SimulationAgentMessenger {
     /**
      * prepares message that when sent to simulation agent will result in correct room climate
@@ -105,17 +103,5 @@ public class SimulationAgentMessenger {
             throws Codec.CodecException, OntologyException {
         UpdateMachinery request = new UpdateMachinery(machinery, roomId);
         return createActionMessage(myAgent, simulationAgent, request, MachineryOntology.getInstance());
-    }
-
-    private static ACLMessage createActionMessage(Agent myAgent, AID simulationAgent, jade.content.AgentAction request,
-                                                  Ontology ontologyInstance)
-            throws Codec.CodecException, OntologyException {
-        ACLMessage msg = new ACLMessage(ACLMessage.REQUEST);
-        msg.addReceiver(simulationAgent);
-        msg.setLanguage(FIPANames.ContentLanguage.FIPA_SL0);
-        msg.setOntology(ontologyInstance.getName());
-        Action action = new Action(simulationAgent, request);
-        myAgent.getContentManager().fillContent(msg, action);
-        return msg;
     }
 }

--- a/src/main/java/hvac/util/CommonMessengerFunctions.java
+++ b/src/main/java/hvac/util/CommonMessengerFunctions.java
@@ -1,0 +1,25 @@
+package hvac.util;
+
+import jade.content.lang.Codec;
+import jade.content.onto.Ontology;
+import jade.content.onto.OntologyException;
+import jade.content.onto.basic.Action;
+import jade.core.AID;
+import jade.core.Agent;
+import jade.domain.FIPANames;
+import jade.lang.acl.ACLMessage;
+
+public class CommonMessengerFunctions {
+
+    public static ACLMessage createActionMessage(Agent myAgent, AID receivingAgent, jade.content.AgentAction request,
+                                                  Ontology ontologyInstance)
+            throws Codec.CodecException, OntologyException {
+        ACLMessage msg = new ACLMessage(ACLMessage.REQUEST);
+        msg.addReceiver(receivingAgent);
+        msg.setLanguage(FIPANames.ContentLanguage.FIPA_SL0);
+        msg.setOntology(ontologyInstance.getName());
+        Action action = new Action(receivingAgent, request);
+        myAgent.getContentManager().fillContent(msg, action);
+        return msg;
+    }
+}

--- a/src/main/java/hvac/util/Conversions.java
+++ b/src/main/java/hvac/util/Conversions.java
@@ -3,6 +3,7 @@ package hvac.util;
 import hvac.ontologies.machinery.MachineParameter;
 import hvac.ontologies.weather.WeatherSnapshot;
 import hvac.simulation.rooms.RoomClimate;
+import jade.util.leap.ArrayList;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -49,5 +50,11 @@ public class Conversions {
         } catch (ClassCastException e) {
             throw new IllegalArgumentException("elements of given jade list are not of type required for result list");
         }
+    }
+
+    public static <T> jade.util.leap.List toJadeList(List<T> javaList) {
+        ArrayList arrayList = new ArrayList();
+        javaList.forEach(arrayList::add);
+        return arrayList;
     }
 }


### PR DESCRIPTION
Modified room coordinator to send to upkeeper not only the upcoming meeting but all meetings that start withing 30 minutes from now whenever list of meetings starting in that period changes. It allows upkeeper to prepare for upcoming meetings and lets room coordinator cancel meetings in upkeeper - just send him an empty list.