### PR TITLE
Non meeting rooms

### DIFF
--- a/src/main/java/hvac/coordinator/CoordinatorAgent.java
+++ b/src/main/java/hvac/coordinator/CoordinatorAgent.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import static hvac.util.Helpers.initTimeFromArgs;
 import static hvac.util.Helpers.loadMap;
 
-@SuppressWarnings("unused")
 public class CoordinatorAgent extends Agent {
     Connection database;
     Calendar calendar;
@@ -67,14 +66,26 @@ public class CoordinatorAgent extends Agent {
             try {
                 newContainer.createNewAgent("room-coordinator-" + room.getId(),
                         RoomCoordinatorAgent.class.getCanonicalName(),
-                        new Object[]{getArguments()[0], getArguments()[1], room.getId(), getAID(), myNeighboursIds, myWalls}).start();
+                        new Object[]{
+                                getArguments()[0],
+                                getArguments()[1],
+                                room.getId(),
+                                getAID(),
+                                myNeighboursIds,
+                                myWalls,
+                                room.isMeetingRoom()}).start();
 
                 newContainer.createNewAgent("upkeeper-" + room.getId(),
                         "hvac.roomupkeeper.RoomUpkeeperAgent",
-                        new Object[]{getArguments()[0], getArguments()[1], room.getId(), room.getArea()}).start();
+                        new Object[]{
+                                getArguments()[0],
+                                getArguments()[1],
+                                room.getId(),
+                                room.getArea()}).start();
             } catch (Exception e) {
                 e.printStackTrace();
             }
+            if(room.isMeetingRoom())
             context.addRoom(room.getSeats(),
                     new AID("room-coordinator-" + room.getId() + "@" + newContainer.getPlatformName(),AID.ISGUID));
         }

--- a/src/main/java/hvac/coordinator/CoordinatorAgent.java
+++ b/src/main/java/hvac/coordinator/CoordinatorAgent.java
@@ -73,7 +73,8 @@ public class CoordinatorAgent extends Agent {
                                 getAID(),
                                 myNeighboursIds,
                                 myWalls,
-                                room.isMeetingRoom()}).start();
+                                room.isMeetingRoom(),
+                                room.getSeats()}).start();
 
                 newContainer.createNewAgent("upkeeper-" + room.getId(),
                         "hvac.roomupkeeper.RoomUpkeeperAgent",

--- a/src/main/java/hvac/ontologies/meeting/Meeting.java
+++ b/src/main/java/hvac/ontologies/meeting/Meeting.java
@@ -6,6 +6,7 @@ import jade.content.Concept;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.Objects;
 
 @SuppressWarnings("unused")
 public class Meeting implements Concept, Comparable<Meeting> {
@@ -125,5 +126,22 @@ public class Meeting implements Concept, Comparable<Meeting> {
                 ", peopleInRoom=" + peopleInRoom +
                 ", temperature=" + temperature +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Meeting meeting = (Meeting) o;
+        return peopleInRoom == meeting.peopleInRoom &&
+                Float.compare(meeting.temperature, temperature) == 0 &&
+                Objects.equals(meetingID, meeting.meetingID) &&
+                startDate.equals(meeting.startDate) &&
+                endDate.equals(meeting.endDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(meetingID, startDate, endDate, peopleInRoom, temperature);
     }
 }

--- a/src/main/java/hvac/ontologies/presence/Presence.java
+++ b/src/main/java/hvac/ontologies/presence/Presence.java
@@ -74,4 +74,7 @@ public class Presence implements Concept {
     public void setUntil(Date until) {
         this.until = Conversions.toLocalDateTime(until);
     }
+    public boolean isValid() {
+        return since.isBefore(until);
+    }
 }

--- a/src/main/java/hvac/ontologies/presence/Presence.java
+++ b/src/main/java/hvac/ontologies/presence/Presence.java
@@ -1,0 +1,77 @@
+package hvac.ontologies.presence;
+
+import hvac.util.Conversions;
+import jade.content.Concept;
+import jade.content.onto.annotations.SuppressSlot;
+import jade.core.AID;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@SuppressWarnings("unused")
+public class Presence implements Concept {
+    private AID person;
+    private int roomId;
+    private LocalDateTime since;
+    private LocalDateTime until;
+
+    public Presence(AID person, int roomId, LocalDateTime since, LocalDateTime until) {
+        this.person = person;
+        this.roomId = roomId;
+        this.since = since;
+        this.until = until;
+    }
+
+    public Presence() {
+    }
+
+    public AID getPerson() {
+        return person;
+    }
+
+    public void setPerson(AID person) {
+        this.person = person;
+    }
+
+    public int getRoomId() {
+        return roomId;
+    }
+
+    public void setRoomId(int roomId) {
+        this.roomId = roomId;
+    }
+
+
+    @SuppressSlot
+    public LocalDateTime getSinceLocal() {
+        return since;
+    }
+
+    public void setSinceLocal(LocalDateTime since) {
+        this.since = since;
+    }
+
+    public Date getSince() {
+        return Conversions.toDate(since);
+    }
+
+    public void setSince(Date since) {
+        this.since = Conversions.toLocalDateTime(since);
+    }
+
+    @SuppressSlot
+    public LocalDateTime getUntilLocal() {
+        return until;
+    }
+
+    public void setUntilLocal(LocalDateTime until) {
+        this.until = until;
+    }
+    public Date getUntil() {
+        return Conversions.toDate(until);
+    }
+
+    public void setUntil(Date until) {
+        this.until = Conversions.toLocalDateTime(until);
+    }
+}

--- a/src/main/java/hvac/ontologies/presence/Presence.java
+++ b/src/main/java/hvac/ontologies/presence/Presence.java
@@ -2,6 +2,7 @@ package hvac.ontologies.presence;
 
 import hvac.util.Conversions;
 import jade.content.Concept;
+import jade.content.onto.annotations.Slot;
 import jade.content.onto.annotations.SuppressSlot;
 import jade.core.AID;
 
@@ -25,6 +26,7 @@ public class Presence implements Concept {
     public Presence() {
     }
 
+    @Slot(mandatory = true)
     public AID getPerson() {
         return person;
     }
@@ -33,6 +35,7 @@ public class Presence implements Concept {
         this.person = person;
     }
 
+    @Slot(mandatory = true)
     public int getRoomId() {
         return roomId;
     }
@@ -75,6 +78,6 @@ public class Presence implements Concept {
         this.until = Conversions.toLocalDateTime(until);
     }
     public boolean isValid() {
-        return since.isBefore(until);
+        return !(since == null && until == null) && (since == null || until == null || since.isBefore(until));
     }
 }

--- a/src/main/java/hvac/ontologies/presence/PresenceOntology.java
+++ b/src/main/java/hvac/ontologies/presence/PresenceOntology.java
@@ -1,0 +1,26 @@
+package hvac.ontologies.presence;
+import jade.content.onto.BeanOntology;
+import jade.content.onto.Ontology;
+
+public class PresenceOntology extends BeanOntology {
+    public static final String ONTOLOGY_NAME = "Presence-ontology";
+
+    private static final Ontology theInstance = new PresenceOntology();
+
+    public static Ontology getInstance() {return theInstance;}
+
+    public PresenceOntology() {
+        super(ONTOLOGY_NAME);
+        try {
+            add(Presence.class);
+            add(PresencesInfo.class);
+            add(RequestAddPresence.class);
+            add(RequestCurrentPresences.class);
+        }
+        catch (Exception oe) {oe.printStackTrace();}
+    }
+
+
+
+
+}

--- a/src/main/java/hvac/ontologies/presence/PresencesInfo.java
+++ b/src/main/java/hvac/ontologies/presence/PresencesInfo.java
@@ -1,11 +1,13 @@
 package hvac.ontologies.presence;
 
 import jade.content.Predicate;
+import jade.content.onto.annotations.AggregateSlot;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class PresencesInfo implements Predicate {
-    private List<Presence> presences;
+    private List<Presence> presences = new ArrayList<>();
 
     public PresencesInfo() {
     }
@@ -13,7 +15,7 @@ public class PresencesInfo implements Predicate {
     public PresencesInfo(List<Presence> presences) {
         this.presences = presences;
     }
-
+    @AggregateSlot
     public List<Presence> getPresences() {
         return presences;
     }

--- a/src/main/java/hvac/ontologies/presence/PresencesInfo.java
+++ b/src/main/java/hvac/ontologies/presence/PresencesInfo.java
@@ -1,0 +1,24 @@
+package hvac.ontologies.presence;
+
+import jade.content.Predicate;
+
+import java.util.List;
+
+public class PresencesInfo implements Predicate {
+    private List<Presence> presences;
+
+    public PresencesInfo() {
+    }
+
+    public PresencesInfo(List<Presence> presences) {
+        this.presences = presences;
+    }
+
+    public List<Presence> getPresences() {
+        return presences;
+    }
+
+    public void setPresences(List<Presence> presences) {
+        this.presences = presences;
+    }
+}

--- a/src/main/java/hvac/ontologies/presence/RequestAddPresence.java
+++ b/src/main/java/hvac/ontologies/presence/RequestAddPresence.java
@@ -1,0 +1,23 @@
+package hvac.ontologies.presence;
+
+import jade.content.AgentAction;
+
+@SuppressWarnings("unused")
+public class RequestAddPresence implements AgentAction {
+    private Presence presence;
+
+    public RequestAddPresence() {
+    }
+
+    public RequestAddPresence(Presence presence) {
+        this.presence = presence;
+    }
+
+    public Presence getPresence() {
+        return presence;
+    }
+
+    public void setPresence(Presence presence) {
+        this.presence = presence;
+    }
+}

--- a/src/main/java/hvac/ontologies/presence/RequestCurrentPresences.java
+++ b/src/main/java/hvac/ontologies/presence/RequestCurrentPresences.java
@@ -1,0 +1,6 @@
+package hvac.ontologies.presence;
+
+import jade.content.AgentAction;
+
+public class RequestCurrentPresences implements AgentAction {
+}

--- a/src/main/java/hvac/roomcoordinator/RoomContext.java
+++ b/src/main/java/hvac/roomcoordinator/RoomContext.java
@@ -99,6 +99,10 @@ public class RoomContext {
             }
         }
     }
+    public void setMeetings(List<Meeting> meetings) {
+        this.meetingsQueue.clear();
+        this.meetingsQueue.addAll(meetings);
+    }
 
     public void newForecastEntry(Meeting meeting){
         neighboursForecastStatus.put(meeting.getMeetingID(), new AbstractMap.SimpleEntry<>(meeting, new HashMap<>()));

--- a/src/main/java/hvac/roomcoordinator/RoomContext.java
+++ b/src/main/java/hvac/roomcoordinator/RoomContext.java
@@ -20,11 +20,13 @@ public class RoomContext {
     private final Map<String, AbstractMap.SimpleEntry<Meeting, Map<AID, Float>>> neighboursForecastStatus = new HashMap<>();
     private final Logger logger = new Logger();
     private final boolean meetingRoom;
+    private final int seats;
 
-    RoomContext(int myRoomId, AID coordinator, boolean meetingRoom){
+    RoomContext(int myRoomId, AID coordinator, boolean meetingRoom, int seats){
         this.myRoomId = myRoomId;
         this.coordinator = coordinator;
         this.meetingRoom = meetingRoom;
+        this.seats = seats;
     }
 
     public int getMyRoomId() {
@@ -130,5 +132,9 @@ public class RoomContext {
             forecastSum += entry.getValue() * factor;
         }
         return forecastSum/factorSum;
+    }
+
+    public int getSeats() {
+        return seats;
     }
 }

--- a/src/main/java/hvac/roomcoordinator/RoomContext.java
+++ b/src/main/java/hvac/roomcoordinator/RoomContext.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 public class RoomContext {
-    private static final float defaultTemperature = 21;
+    private static final float defaultTemperature = 21+273;
     private final int myRoomId;
     private final AID coordinator;
     private AID myRoomUpkeeper;
@@ -19,10 +19,12 @@ public class RoomContext {
     private final PriorityQueue<Meeting> meetingsQueue = new PriorityQueue<>();
     private final Map<String, AbstractMap.SimpleEntry<Meeting, Map<AID, Float>>> neighboursForecastStatus = new HashMap<>();
     private final Logger logger = new Logger();
+    private final boolean meetingRoom;
 
-    RoomContext(int myRoomId, AID coordinator){
+    RoomContext(int myRoomId, AID coordinator, boolean meetingRoom){
         this.myRoomId = myRoomId;
         this.coordinator = coordinator;
+        this.meetingRoom = meetingRoom;
     }
 
     public int getMyRoomId() {
@@ -51,6 +53,10 @@ public class RoomContext {
 
     public void addMeeting(Meeting meeting){
         meetingsQueue.add(meeting);
+    }
+
+    public boolean isMeetingRoom() {
+        return meetingRoom;
     }
 
     public List<Meeting> getMeetingsStartingBefore(LocalDateTime date){

--- a/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
+++ b/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
@@ -7,6 +7,7 @@ import hvac.roomcoordinator.behaviours.MeetingHandlingBehaviour;
 import hvac.roomcoordinator.behaviours.PeopleHandlingBehaviour;
 import hvac.roomcoordinator.behaviours.UpkeeperManagingBehaviour;
 import hvac.simulation.rooms.RoomWall;
+import hvac.util.behaviours.NotUnderstoodBehaviour;
 import hvac.util.df.DfHelpers;
 import hvac.util.df.FindingBehaviour;
 import jade.content.lang.sl.SLCodec;
@@ -81,11 +82,24 @@ public class RoomCoordinatorAgent extends Agent {
         if (Ids.size() == roomsProcessed) {
             UpkeeperManagingBehaviour upkeeperManagingBehaviour = new UpkeeperManagingBehaviour(this, 1000, roomContext);
             addBehaviour(upkeeperManagingBehaviour);
-            addBehaviour(new ConditionsInformingBehaviour(this, roomContext));
+            ConditionsInformingBehaviour conditionsInformingBehaviour = new ConditionsInformingBehaviour(this, roomContext);
+            addBehaviour(conditionsInformingBehaviour);
             if(roomContext.isMeetingRoom()) {
-                addBehaviour(new MeetingHandlingBehaviour(this, roomContext, upkeeperManagingBehaviour));
+                MeetingHandlingBehaviour meetingHandlingBehaviour = new MeetingHandlingBehaviour(this, roomContext, upkeeperManagingBehaviour);
+                addBehaviour(meetingHandlingBehaviour);
+
+                addBehaviour(new NotUnderstoodBehaviour(this, roomContext.getLogger(),
+                        upkeeperManagingBehaviour.getTemplate(),
+                        conditionsInformingBehaviour.getTemplate(),
+                        meetingHandlingBehaviour.getTemplate()));
             } else {
-                addBehaviour(new PeopleHandlingBehaviour(this, roomContext, upkeeperManagingBehaviour));
+                PeopleHandlingBehaviour peopleHandlingBehaviour = new PeopleHandlingBehaviour(this, roomContext, upkeeperManagingBehaviour);
+                addBehaviour(peopleHandlingBehaviour);
+
+                addBehaviour(new NotUnderstoodBehaviour(this, roomContext.getLogger(),
+                        upkeeperManagingBehaviour.getTemplate(),
+                        conditionsInformingBehaviour.getTemplate(),
+                        peopleHandlingBehaviour.getTemplate()));
             }
             roomContext.getLogger().log("Successfully initialized and found all my neighbours and upkeeper");
             return;

--- a/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
+++ b/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgent.java
@@ -40,8 +40,8 @@ public class RoomCoordinatorAgent extends Agent {
 
     @SuppressWarnings("unchecked")
     private RoomContext getContext() {
-        if(getArguments().length != 7) {
-            usage("incorrect number of arguments, required:7, provided: " + getArguments().length);
+        if(getArguments().length != 8) {
+            usage("incorrect number of arguments, required:8, provided: " + getArguments().length);
         }
         int myRoomId;
         try {
@@ -54,7 +54,17 @@ public class RoomCoordinatorAgent extends Agent {
             usage("room cannot be registered in DF");
             return null;
         }
-        RoomContext newRoomContext = new RoomContext(myRoomId, (AID) getArguments()[3], (boolean)getArguments()[6]);
+        int seats;
+        try {
+            seats = Integer.parseInt(getArguments()[7].toString());
+        } catch (NumberFormatException e) {
+            usage("seats amount is not valid");
+            return null;
+        }
+        RoomContext newRoomContext = new RoomContext(myRoomId,
+                (AID) getArguments()[3],
+                (boolean)getArguments()[6],
+                seats);
         newRoomContext.getLogger().setAgentName("room coordinator (" + newRoomContext.getMyRoomId() + ")");
         try {
             Ids = (ArrayList<Integer>) getArguments()[4];
@@ -114,7 +124,7 @@ public class RoomCoordinatorAgent extends Agent {
 
     private void usage(String err) {
         System.err.println("-------- Room Coordinator agent usage --------------");
-        System.err.println("simulation:hvac.roomcoordinator.RoomCoordinatorAgent(timeScale, start_date, RoomId, CoordinatorAID, NeighboursIds, RoomWalls, isMeetingRoom)");
+        System.err.println("simulation:hvac.roomcoordinator.RoomCoordinatorAgent(timeScale, start_date, RoomId, CoordinatorAID, NeighboursIds, RoomWalls, isMeetingRoom, seats)");
         System.err.println("timescale - floating point value indicating speed of passing time");
         System.err.println("Date from which to start simulating \"yyyy-MM-dd HH:mm:ss\"");
         System.err.println("RoomId - integer uniquely identifying the room of this agent");
@@ -122,6 +132,7 @@ public class RoomCoordinatorAgent extends Agent {
         System.err.println("NeighboursIds - array of neighbours' Ids");
         System.err.println("RoomWalls - array of walls' properties");
         System.err.println("IsMeetingRoom - boolean indicating if this room will be used for meetings");
+        System.err.println("seats - number of seats in this room");
         System.err.println("err:" + err);
     }
 }

--- a/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgentMessenger.java
+++ b/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgentMessenger.java
@@ -1,0 +1,110 @@
+package hvac.roomcoordinator;
+
+import hvac.ontologies.presence.Presence;
+import hvac.ontologies.presence.PresenceOntology;
+import hvac.ontologies.presence.RequestAddPresence;
+import hvac.ontologies.presence.RequestCurrentPresences;
+import hvac.util.CommonMessengerFunctions;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
+import jade.core.AID;
+import jade.core.Agent;
+import jade.lang.acl.ACLMessage;
+
+import java.time.LocalDateTime;
+
+@SuppressWarnings("unused")
+public class RoomCoordinatorAgentMessenger {
+    /**
+     * prepares message that when sent to room coordinator agent for non meeting room
+     * will result in list of that room presences
+     * Requires that agent has registered sl0 language and presence ontology
+     * @param myAgent agent that will send the message
+     * @param roomCoordinator room coordinator agent to which message will be sent
+     * @return prepared message
+     * @throws Codec.CodecException language fipa-sl0 is not registered
+     * @throws OntologyException presence ontology is not registered
+     */
+    public static ACLMessage prepareRequestCurrentPresences(Agent myAgent, AID roomCoordinator)
+            throws Codec.CodecException, OntologyException {
+        RequestCurrentPresences requestCurrentPresences = new RequestCurrentPresences();
+        return CommonMessengerFunctions.createActionMessage(
+                myAgent, roomCoordinator, requestCurrentPresences, PresenceOntology.getInstance());
+    }
+    /**
+     * prepares message that when sent to room coordinator agent for non meeting room
+     * will result in it being added to that agents presences - conditions will be maintained in that room for
+     * that person in that time period
+     * Won't work if person already registered that presence in this room and it that presence until is not in the past
+     * or if there is not enough room for given time period - check that with RequestCurrentPresences
+     * Requires that agent has registered sl0 language and presence ontology
+     * @param startTime time when person wants to enter the room
+     * @param endTime time when person wants to leave the room
+     * @param roomId room of given room coordinator
+     * @param myAgent agent that will send the message
+     * @param roomCoordinator room coordinator agent to which message will be sent
+     * @return prepared message
+     * @throws Codec.CodecException language fipa-sl0 is not registered
+     * @throws OntologyException presence ontology is not registered
+     */
+    public static ACLMessage prepareRequestAddPresence(LocalDateTime startTime, LocalDateTime endTime,
+                                                       int roomId, Agent myAgent, AID roomCoordinator)
+            throws Codec.CodecException, OntologyException {
+        RequestAddPresence requestAddPresence = new RequestAddPresence(
+                new Presence(myAgent.getAID(), roomId, startTime, endTime)
+        );
+        return CommonMessengerFunctions.createActionMessage(
+                myAgent, roomCoordinator, requestAddPresence, PresenceOntology.getInstance());
+    }
+    /**
+     * prepares message that when sent to room coordinator agent for non meeting room
+     * will result in it being added to that agents presences - conditions will be maintained in that room for
+     * that person in that time period
+     * Only start time is included - conditions will be maintained starting from given point in time
+     * or if there is not enough room for given time period - check that with RequestCurrentPresences
+     * Another message should be sent to set end time
+     * Won't work if person already registered that presence in this room and it that presence until is not in the past
+     * or if there is not enough room for given time period - check that with RequestCurrentPresences
+     * Requires that agent has registered sl0 language and presence ontology
+     * @param startTime time when person wants to enter the room
+     * @param roomId room of given room coordinator
+     * @param myAgent agent that will send the message
+     * @param roomCoordinator room coordinator agent to which message will be sent
+     * @return prepared message
+     * @throws Codec.CodecException language fipa-sl0 is not registered
+     * @throws OntologyException presence ontology is not registered
+     */
+    public static ACLMessage prepareRequestAddPresenceOnlyStart(LocalDateTime startTime,
+                                                       int roomId, Agent myAgent, AID roomCoordinator)
+            throws Codec.CodecException, OntologyException {
+        RequestAddPresence requestAddPresence = new RequestAddPresence(
+                new Presence(myAgent.getAID(), roomId, startTime, null)
+        );
+        return CommonMessengerFunctions.createActionMessage(
+                myAgent, roomCoordinator, requestAddPresence, PresenceOntology.getInstance());
+    }
+    /**
+     * prepares message that when sent to room coordinator agent for non meeting room
+     * will result in it being added to that agents presences - conditions will be maintained in that room for
+     * that person in that time period
+     * Only end time is included - requires sending message with only start time first and that start time should be
+     * before this end time
+     * Requires that agent has registered sl0 language and presence ontology
+     * @param endTime time when person wants to leave the room
+     * @param roomId room of given room coordinator
+     * @param myAgent agent that will send the message
+     * @param roomCoordinator room coordinator agent to which message will be sent
+     * @return prepared message
+     * @throws Codec.CodecException language fipa-sl0 is not registered
+     * @throws OntologyException presence ontology is not registered
+     */
+    public static ACLMessage prepareRequestAddPresenceOnlyEnd(LocalDateTime endTime,
+                                                                int roomId, Agent myAgent, AID roomCoordinator)
+            throws Codec.CodecException, OntologyException {
+        RequestAddPresence requestAddPresence = new RequestAddPresence(
+                new Presence(myAgent.getAID(), roomId, null, endTime)
+        );
+        return CommonMessengerFunctions.createActionMessage(
+                myAgent, roomCoordinator, requestAddPresence, PresenceOntology.getInstance());
+    }
+}

--- a/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgentMessenger.java
+++ b/src/main/java/hvac/roomcoordinator/RoomCoordinatorAgentMessenger.java
@@ -1,10 +1,8 @@
 package hvac.roomcoordinator;
 
-import hvac.ontologies.presence.Presence;
-import hvac.ontologies.presence.PresenceOntology;
-import hvac.ontologies.presence.RequestAddPresence;
-import hvac.ontologies.presence.RequestCurrentPresences;
+import hvac.ontologies.presence.*;
 import hvac.util.CommonMessengerFunctions;
+import jade.content.ContentElement;
 import jade.content.lang.Codec;
 import jade.content.onto.OntologyException;
 import jade.core.AID;
@@ -12,6 +10,7 @@ import jade.core.Agent;
 import jade.lang.acl.ACLMessage;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @SuppressWarnings("unused")
 public class RoomCoordinatorAgentMessenger {
@@ -31,6 +30,25 @@ public class RoomCoordinatorAgentMessenger {
         return CommonMessengerFunctions.createActionMessage(
                 myAgent, roomCoordinator, requestCurrentPresences, PresenceOntology.getInstance());
     }
+
+    /**
+     * Extracts presences info from message received from weather forecaster
+     * Requires that agent has registered sl0 language and presence ontology
+     * @param myAgent calling agent
+     * @param msg message with presences info
+     * @return extracted presences info if message contains one
+     * @throws Codec.CodecException sl0 language is not registered or message is not in this language
+     * @throws OntologyException presence ontology is not registered or message is not in this ontology
+     */
+    public static Optional<PresencesInfo> extractPresencesInfo(Agent myAgent, ACLMessage msg)
+            throws Codec.CodecException, OntologyException {
+        ContentElement content = myAgent.getContentManager().extractContent(msg);
+        if(content instanceof PresencesInfo) {
+            return Optional.of((PresencesInfo)content);
+        }
+        return Optional.empty();
+    }
+
     /**
      * prepares message that when sent to room coordinator agent for non meeting room
      * will result in it being added to that agents presences - conditions will be maintained in that room for

--- a/src/main/java/hvac/roomcoordinator/behaviours/ConditionsInformingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/ConditionsInformingBehaviour.java
@@ -51,7 +51,7 @@ public class ConditionsInformingBehaviour extends RequestProcessingBehaviour {
     }
 
     @Override
-    protected MessageTemplate getTemplate() {
+    public MessageTemplate getTemplate() {
         return template;
     }
 }

--- a/src/main/java/hvac/roomcoordinator/behaviours/ConditionsInformingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/ConditionsInformingBehaviour.java
@@ -1,0 +1,57 @@
+package hvac.roomcoordinator.behaviours;
+
+import hvac.ontologies.meeting.MeetingOntology;
+import hvac.ontologies.meeting.Request;
+import hvac.ontologies.meeting.RequestStatus;
+import hvac.roomcoordinator.RoomContext;
+import hvac.util.behaviours.RequestProcessingBehaviour;
+import jade.content.Concept;
+import jade.content.ContentElement;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
+import jade.content.onto.basic.Action;
+import jade.core.Agent;
+import jade.domain.FIPANames;
+import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
+
+import static hvac.util.SimpleReplies.replyNotUnderstood;
+
+public class ConditionsInformingBehaviour extends RequestProcessingBehaviour {
+    private final RoomContext context;
+    private final MessageTemplate template = MessageTemplate.and(
+            MessageTemplate.and(
+                    MessageTemplate.MatchOntology(MeetingOntology.getInstance().getName()),
+                    MessageTemplate.MatchLanguage(FIPANames.ContentLanguage.FIPA_SL0)
+            ),
+            MessageTemplate.MatchPerformative(ACLMessage.REQUEST)
+    );
+    public ConditionsInformingBehaviour(Agent myAgent, RoomContext context) {
+        super(myAgent, context.getLogger());
+        this.context = context;
+    }
+
+    @Override
+    protected void processRequest(ACLMessage msg) throws Codec.CodecException, OntologyException {
+        ContentElement ce = myAgent.getContentManager().extractContent(msg);
+        if (ce instanceof Action) {
+            Concept action = ((Action) ce).getAction();
+            if (action instanceof Request) {
+                Request request = (Request) action;
+                request.getMeeting().setTemperature(context.estimateTemperatureForNeighbour(request.getMeeting()));
+                ACLMessage reply = msg.createReply();
+                reply.setPerformative(ACLMessage.INFORM);
+                request.setStatus(RequestStatus.ESTIMATION);
+                myAgent.getContentManager().fillContent(reply, new Action(myAgent.getAID(), request));
+                myAgent.send(reply);
+                return;
+            }
+        }
+        replyNotUnderstood(myAgent, msg);
+    }
+
+    @Override
+    protected MessageTemplate getTemplate() {
+        return template;
+    }
+}

--- a/src/main/java/hvac/roomcoordinator/behaviours/MeetingHandlingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/MeetingHandlingBehaviour.java
@@ -2,6 +2,7 @@ package hvac.roomcoordinator.behaviours;
 
 import hvac.ontologies.meeting.Request;
 import hvac.ontologies.meeting.RequestStatus;
+import hvac.ontologies.presence.PresenceOntology;
 import hvac.roomcoordinator.RoomContext;
 import jade.content.onto.basic.Action;
 import jade.core.AID;
@@ -10,18 +11,29 @@ import jade.core.behaviours.CyclicBehaviour;
 import jade.lang.acl.ACLMessage;
 import jade.lang.acl.MessageTemplate;
 
-public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
+public class MeetingHandlingBehaviour extends CyclicBehaviour {
     private final RoomContext roomContext;
-    private final RoomCoordinatorTickerBehaviour tickerBehaviour;
+    private final UpkeeperManagingBehaviour tickerBehaviour;
     private final MessageTemplate messageTemplate;
 
-    public RoomCoordinatorCyclicBehaviour(Agent a, RoomContext roomContext, RoomCoordinatorTickerBehaviour tickerBehaviour) {
+    public MeetingHandlingBehaviour(Agent a, RoomContext roomContext, UpkeeperManagingBehaviour tickerBehaviour) {
         super(a);
         this.roomContext = roomContext;
         this.tickerBehaviour = tickerBehaviour;
-        messageTemplate = MessageTemplate.not(MessageTemplate.MatchSender(
-                roomContext.getMyRoomUpkeeper()
-        ));
+        messageTemplate = MessageTemplate.and(
+                //don't catch UpkeeperManagingBehaviour messages
+                MessageTemplate.not(MessageTemplate.MatchSender(
+                        roomContext.getMyRoomUpkeeper())
+                ),
+                MessageTemplate.and(
+                        //don't catch PeopleHandlingBehaviour messages
+                        MessageTemplate.not(MessageTemplate.MatchOntology(
+                                PresenceOntology.getInstance().getName())
+                        ),
+                        //don't catch ConditionsInformingBehaviour messages
+                        MessageTemplate.not(MessageTemplate.MatchPerformative(
+                                ACLMessage.REQUEST))
+                ));
     }
 
     @Override
@@ -29,19 +41,15 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         ACLMessage msg = myAgent.receive(messageTemplate);
         if (msg != null) {
             handleMessage(msg);
-        }
-        else {
+        } else {
             block();
         }
     }
 
-    private void handleMessage(ACLMessage msg){
-        switch(msg.getPerformative()) {
+    private void handleMessage(ACLMessage msg) {
+        switch (msg.getPerformative()) {
             case ACLMessage.CFP:
                 handleCFP(msg);
-                break;
-            case ACLMessage.REQUEST:
-                handleRequest(msg);
                 break;
             case ACLMessage.INFORM:
                 handleInform(msg);
@@ -60,12 +68,12 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         }
     }
 
-    private void handleCFP(ACLMessage msg){
+    private void handleCFP(ACLMessage msg) {
         Request request = extractRequest(msg);
-        if (null == request){
+        if (null == request) {
             return;
         }
-        if (! roomContext.isTimeSlotAvailable(request.getMeeting())){
+        if (!roomContext.isTimeSlotAvailable(request.getMeeting())) {
             ACLMessage reply = msg.createReply();
             reply.setPerformative(ACLMessage.REFUSE);
             request.setStatus(RequestStatus.FAILED);
@@ -76,7 +84,7 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         requestForecast.setPerformative(ACLMessage.REQUEST);
         requestForecast.setConversationId(requestForecast.getConversationId() + "-req-room-" + roomContext.getMyRoomId());
         requestForecast.clearAllReceiver();
-        for (AID neighbour:roomContext.getMyNeighbours().keySet()){
+        for (AID neighbour : roomContext.getMyNeighbours().keySet()) {
             requestForecast.addReceiver(neighbour);
         }
         request.setStatus(RequestStatus.FORECAST);
@@ -84,28 +92,16 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         fillAndSend(requestForecast, request);
     }
 
-    private void handleRequest(ACLMessage msg){
+    private void handleInform(ACLMessage msg) {
         Request request = extractRequest(msg);
-        if (null == request){
-            return;
-        }
-        request.getMeeting().setTemperature(roomContext.estimateTemperatureForNeighbour(request.getMeeting()));
-        ACLMessage reply = msg.createReply();
-        reply.setPerformative(ACLMessage.INFORM);
-        request.setStatus(RequestStatus.ESTIMATION);
-        fillAndSend(reply, request);
-    }
-
-    private void handleInform(ACLMessage msg){
-        Request request = extractRequest(msg);
-        if (null == request){
+        if (null == request) {
             return;
         }
         roomContext.addNeighbourForecast(
                 request.getMeeting().getMeetingID(),
                 msg.getSender(),
                 request.getMeeting().getTemperature());
-        if (! roomContext.isForecastCompleted(request.getMeeting().getMeetingID())){
+        if (!roomContext.isForecastCompleted(request.getMeeting().getMeetingID())) {
             return;
         }
         request.getMeeting().setTemperature(roomContext.computeForecast(request.getMeeting().getMeetingID()));
@@ -119,18 +115,17 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         fillAndSend(reply, request);
     }
 
-    private void handleAcceptProposal(ACLMessage msg){
+    private void handleAcceptProposal(ACLMessage msg) {
         Request request = extractRequest(msg);
         if (null == request) {
             return;
         }
         ACLMessage reply = msg.createReply();
-        if (roomContext.isTimeSlotAvailable(request.getMeeting())){
+        if (roomContext.isTimeSlotAvailable(request.getMeeting())) {
             reply.setPerformative(ACLMessage.INFORM);
             request.setStatus(RequestStatus.RESERVED);
             roomContext.addMeeting(request.getMeeting());
-        }
-        else {
+        } else {
             reply.setPerformative(ACLMessage.FAILURE);
             request.setStatus(RequestStatus.FAILED);
         }
@@ -138,9 +133,9 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         tickerBehaviour.reset(1);
     }
 
-    private void handleCancel(ACLMessage msg){
+    private void handleCancel(ACLMessage msg) {
         Request request = extractRequest(msg);
-        if (null == request){
+        if (null == request) {
             return;
         }
         roomContext.removeMeeting(request.getMeeting().getMeetingID());
@@ -151,7 +146,7 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         tickerBehaviour.reset(1);
     }
 
-    private void notUnderstood(ACLMessage msg){
+    private void notUnderstood(ACLMessage msg) {
         roomContext.getLogger().log("Not understood " + msg);
         ACLMessage reply = msg.createReply();
         reply.setPerformative(ACLMessage.NOT_UNDERSTOOD);
@@ -159,22 +154,26 @@ public class RoomCoordinatorCyclicBehaviour extends CyclicBehaviour {
         myAgent.send(reply);
     }
 
-    private Request extractRequest(ACLMessage msg){
+    private Request extractRequest(ACLMessage msg) {
         Request request = null;
         try {
             request = (Request) ((Action) myAgent.getContentManager().extractContent(msg)).getAction();
-        } catch (Exception e){e.printStackTrace();}
-        if (null == request || null == request.getMeeting()){
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        if (null == request || null == request.getMeeting()) {
             notUnderstood(msg);
             return null;
         }
         return request;
     }
 
-    private void fillAndSend(ACLMessage msg, Request request){
+    private void fillAndSend(ACLMessage msg, Request request) {
         try {
             myAgent.getContentManager().fillContent(msg, new Action(myAgent.getAID(), request));
-        } catch (Exception e){e.printStackTrace();}
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         msg.clearAllReplyTo();
         msg.setInReplyTo("");
         msg.setReplyWith("");

--- a/src/main/java/hvac/roomcoordinator/behaviours/MeetingHandlingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/MeetingHandlingBehaviour.java
@@ -180,4 +180,8 @@ public class MeetingHandlingBehaviour extends CyclicBehaviour {
         //roomContext.getLogger().log("Message sent: " + msg);
         myAgent.send(msg);
     }
+
+    public MessageTemplate getTemplate() {
+        return messageTemplate;
+    }
 }

--- a/src/main/java/hvac/roomcoordinator/behaviours/PeopleHandlingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/PeopleHandlingBehaviour.java
@@ -51,7 +51,6 @@ public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
             } else if (action instanceof RequestAddPresence) {
                 RequestAddPresence requestAddPresence = (RequestAddPresence) action;
                 handleRequestAddPresence(msg, requestAddPresence);
-                context.getLogger().log(msg.toString());
                 handled = true;
             }
         }
@@ -130,8 +129,7 @@ public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
 
     //checks if at any point there will be too many people in the room
     private boolean arePresencesValid(List<Presence> presenceList) {
-        //TODO:replace with chairs count from coordinator
-        int maxPresences = 3;
+        int maxPresences = context.getSeats();
         LinkedList<Presence> concurrentPresences = new LinkedList<>();
         for (Presence presence :
                 presenceList) {

--- a/src/main/java/hvac/roomcoordinator/behaviours/PeopleHandlingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/PeopleHandlingBehaviour.java
@@ -1,8 +1,6 @@
 package hvac.roomcoordinator.behaviours;
 
-import hvac.ontologies.presence.PresenceOntology;
-import hvac.ontologies.presence.RequestAddPresence;
-import hvac.ontologies.presence.RequestCurrentPresences;
+import hvac.ontologies.presence.*;
 import hvac.roomcoordinator.RoomContext;
 import hvac.util.behaviours.RequestProcessingBehaviour;
 import jade.content.Concept;
@@ -15,7 +13,11 @@ import jade.domain.FIPANames;
 import jade.lang.acl.ACLMessage;
 import jade.lang.acl.MessageTemplate;
 
-import static hvac.util.SimpleReplies.replyNotUnderstood;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import static hvac.util.SimpleReplies.*;
 
 public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
     private final RoomContext context;
@@ -24,6 +26,7 @@ public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
             MessageTemplate.MatchLanguage(FIPANames.ContentLanguage.FIPA_SL0),
             MessageTemplate.MatchOntology(PresenceOntology.getInstance().getName())
     );
+    private final List<Presence> presences = new ArrayList<>();
 
     public PeopleHandlingBehaviour(Agent agent, RoomContext context, UpkeeperManagingBehaviour upkeeperManagingBehaviour) {
         super(agent, context.getLogger());
@@ -37,15 +40,81 @@ public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
         if (ce instanceof Action) {
             Concept action = ((Action) ce).getAction();
             if (action instanceof RequestCurrentPresences) {
-                RequestCurrentPresences requestCurrentPresences = (RequestCurrentPresences) action;
-                context.getLogger().log(msg.toString());
+                handleRequestCurrentPresences(msg);
                 return;
             } else if (action instanceof RequestAddPresence) {
                 RequestAddPresence requestAddPresence = (RequestAddPresence) action;
+                handleRequestAddPresence(msg, requestAddPresence);
                 context.getLogger().log(msg.toString());
+                return;
             }
         }
         replyNotUnderstood(myAgent, msg);
+    }
+
+    private void handleRequestCurrentPresences(ACLMessage msg) throws Codec.CodecException, OntologyException {
+        PresencesInfo info = new PresencesInfo(presences);
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.INFORM);
+        myAgent.getContentManager().fillContent(reply, info);
+        myAgent.send(reply);
+        context.getLogger().log("replied with presence info to " + msg.getSender());
+    }
+
+    private void handleRequestAddPresence(ACLMessage msg, RequestAddPresence requestAddPresence) {
+        Presence presenceToAdd = requestAddPresence.getPresence();
+        if(!presenceToAdd.isValid() || presenceToAdd.getRoomId() != context.getMyRoomId()) {
+            context.getLogger().log("invalid presence to add " + msg.getContent());
+            replyRefuse(myAgent, msg);
+        }
+        if (presences.size() == 0
+                || presences.get(0).getSinceLocal().isAfter(presenceToAdd.getUntilLocal())) {
+            presences.add(0, presenceToAdd);
+            replyAgree(myAgent, msg);
+        } else if (presences.get(presences.size() - 1).getUntilLocal().isBefore(presenceToAdd.getSinceLocal())) {
+            presences.add(presenceToAdd);
+            replyAgree(myAgent, msg);
+        } else {
+            List<Presence> newPresences = new ArrayList<>(presences);
+            int i = 0;
+            for (; i < newPresences.size(); i++) {
+                if (newPresences.get(i).getSinceLocal().isAfter(presenceToAdd.getSinceLocal())) {
+                    break;
+                }
+            }
+            newPresences.add(i, presenceToAdd);
+            if (arePresencesValid(newPresences)) {
+                context.getLogger().log("found place for " + msg.getSender());
+                presences.clear();
+                presences.addAll(newPresences);
+                replyAgree(myAgent, msg);
+            } else {
+                context.getLogger().log("failed to find place for " + msg.getSender());
+                replyRefuse(myAgent, msg);
+            }
+        }
+    }
+
+    //checks if at any point there will be too many people in the room
+    private boolean arePresencesValid(List<Presence> presenceList) {
+        //TODO:replace with chairs count from coordinator
+        int maxPresences = 3;
+        LinkedList<Presence> concurrentPresences = new LinkedList<>();
+        for (Presence presence :
+                presenceList) {
+            concurrentPresences.removeIf(it->it.getUntilLocal().isBefore(presence.getSinceLocal())
+            || it.getUntilLocal().isEqual(presence.getSinceLocal()));
+            while (concurrentPresences.size() > 0
+                    && (concurrentPresences.getFirst().getUntilLocal().isBefore(presence.getSinceLocal())
+                    || concurrentPresences.getFirst().getUntilLocal().isEqual(presence.getSinceLocal()))) {
+                concurrentPresences.removeFirst();
+            }
+            concurrentPresences.add(presence);
+            if (concurrentPresences.size() > maxPresences) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/hvac/roomcoordinator/behaviours/PeopleHandlingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/PeopleHandlingBehaviour.java
@@ -1,0 +1,56 @@
+package hvac.roomcoordinator.behaviours;
+
+import hvac.ontologies.presence.PresenceOntology;
+import hvac.ontologies.presence.RequestAddPresence;
+import hvac.ontologies.presence.RequestCurrentPresences;
+import hvac.roomcoordinator.RoomContext;
+import hvac.util.behaviours.RequestProcessingBehaviour;
+import jade.content.Concept;
+import jade.content.ContentElement;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
+import jade.content.onto.basic.Action;
+import jade.core.Agent;
+import jade.domain.FIPANames;
+import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
+
+import static hvac.util.SimpleReplies.replyNotUnderstood;
+
+public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
+    private final RoomContext context;
+    private final UpkeeperManagingBehaviour upkeeperManagingBehaviour;
+    private final MessageTemplate template = MessageTemplate.and(
+            MessageTemplate.MatchLanguage(FIPANames.ContentLanguage.FIPA_SL0),
+            MessageTemplate.MatchOntology(PresenceOntology.getInstance().getName())
+    );
+
+    public PeopleHandlingBehaviour(Agent agent, RoomContext context, UpkeeperManagingBehaviour upkeeperManagingBehaviour) {
+        super(agent, context.getLogger());
+        this.context = context;
+        this.upkeeperManagingBehaviour = upkeeperManagingBehaviour;
+    }
+
+    @Override
+    protected void processRequest(ACLMessage msg) throws Codec.CodecException, OntologyException {
+        ContentElement ce = myAgent.getContentManager().extractContent(msg);
+        if (ce instanceof Action) {
+            Concept action = ((Action) ce).getAction();
+            if (action instanceof RequestCurrentPresences) {
+                RequestCurrentPresences requestCurrentPresences = (RequestCurrentPresences) action;
+                context.getLogger().log(msg.toString());
+                return;
+            } else if (action instanceof RequestAddPresence) {
+                RequestAddPresence requestAddPresence = (RequestAddPresence) action;
+                context.getLogger().log(msg.toString());
+            }
+        }
+        replyNotUnderstood(myAgent, msg);
+    }
+
+    @Override
+    protected MessageTemplate getTemplate() {
+        return template;
+    }
+
+}

--- a/src/main/java/hvac/roomcoordinator/behaviours/PeopleHandlingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/PeopleHandlingBehaviour.java
@@ -1,21 +1,25 @@
 package hvac.roomcoordinator.behaviours;
 
+import hvac.ontologies.meeting.Meeting;
 import hvac.ontologies.presence.*;
 import hvac.roomcoordinator.RoomContext;
+import hvac.time.DateTimeSimulator;
 import hvac.util.behaviours.RequestProcessingBehaviour;
 import jade.content.Concept;
 import jade.content.ContentElement;
 import jade.content.lang.Codec;
 import jade.content.onto.OntologyException;
 import jade.content.onto.basic.Action;
+import jade.core.AID;
 import jade.core.Agent;
 import jade.domain.FIPANames;
 import jade.lang.acl.ACLMessage;
 import jade.lang.acl.MessageTemplate;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static hvac.util.SimpleReplies.*;
 
@@ -36,20 +40,30 @@ public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
 
     @Override
     protected void processRequest(ACLMessage msg) throws Codec.CodecException, OntologyException {
+        removeFinishedPresences();
+        boolean handled = false;
         ContentElement ce = myAgent.getContentManager().extractContent(msg);
         if (ce instanceof Action) {
             Concept action = ((Action) ce).getAction();
             if (action instanceof RequestCurrentPresences) {
                 handleRequestCurrentPresences(msg);
-                return;
+                handled = true;
             } else if (action instanceof RequestAddPresence) {
                 RequestAddPresence requestAddPresence = (RequestAddPresence) action;
                 handleRequestAddPresence(msg, requestAddPresence);
                 context.getLogger().log(msg.toString());
-                return;
+                handled = true;
             }
         }
-        replyNotUnderstood(myAgent, msg);
+        reconstructMeetings();
+        upkeeperManagingBehaviour.reset(1);
+        if(!handled) replyNotUnderstood(myAgent, msg);
+    }
+
+    private void removeFinishedPresences() {
+        presences.removeIf(presence ->
+                presence.getUntilLocal() != null
+                        && presence.getUntilLocal().isBefore(DateTimeSimulator.getCurrentDate()));
     }
 
     private void handleRequestCurrentPresences(ACLMessage msg) throws Codec.CodecException, OntologyException {
@@ -63,16 +77,35 @@ public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
 
     private void handleRequestAddPresence(ACLMessage msg, RequestAddPresence requestAddPresence) {
         Presence presenceToAdd = requestAddPresence.getPresence();
+        //if presence is incorrect or not for my room stop handling
         if(!presenceToAdd.isValid() || presenceToAdd.getRoomId() != context.getMyRoomId()) {
             context.getLogger().log("invalid presence to add " + msg.getContent());
             replyRefuse(myAgent, msg);
         }
-        if (presences.size() == 0
-                || presences.get(0).getSinceLocal().isAfter(presenceToAdd.getUntilLocal())) {
+        //if presence only indicates end time search for matching start time and update that presence with end time
+        else if(presenceToAdd.getSinceLocal() == null) {
+            for(int i = presences.size()-1; i>= 0; i--) {
+                Presence presence = presences.get(i);
+                if(presence.getPerson().equals(presenceToAdd.getPerson())
+                    && presence.getUntilLocal() == null) {
+                    context.getLogger().log("set leave time for " + msg.getSender());
+                    presence.setUntilLocal(presenceToAdd.getUntilLocal());
+                    replyAgree(myAgent, msg);
+                    return;
+                }
+            }
+            context.getLogger().log("no matching enter time for given leave time for person " + msg.getSender());
+            replyRefuse(myAgent, msg);
+            //if presence is not end time and for person already in presences stop handling
+        } else if(presences.stream().anyMatch(presence->presence.getPerson().equals(presenceToAdd.getPerson()))) {
+            context.getLogger().log("can't add presence for a person (this person already added their presence) " + msg.getSender());
+            replyRefuse(myAgent, msg);
+        }
+        //if presence is first presence to add or ends before first presence starts then we can just add it
+        else if (presences.size() == 0
+                || presenceToAdd.getUntilLocal() != null
+                && presences.get(0).getSinceLocal().isAfter(presenceToAdd.getUntilLocal())) {
             presences.add(0, presenceToAdd);
-            replyAgree(myAgent, msg);
-        } else if (presences.get(presences.size() - 1).getUntilLocal().isBefore(presenceToAdd.getSinceLocal())) {
-            presences.add(presenceToAdd);
             replyAgree(myAgent, msg);
         } else {
             List<Presence> newPresences = new ArrayList<>(presences);
@@ -102,13 +135,9 @@ public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
         LinkedList<Presence> concurrentPresences = new LinkedList<>();
         for (Presence presence :
                 presenceList) {
-            concurrentPresences.removeIf(it->it.getUntilLocal().isBefore(presence.getSinceLocal())
-            || it.getUntilLocal().isEqual(presence.getSinceLocal()));
-            while (concurrentPresences.size() > 0
-                    && (concurrentPresences.getFirst().getUntilLocal().isBefore(presence.getSinceLocal())
-                    || concurrentPresences.getFirst().getUntilLocal().isEqual(presence.getSinceLocal()))) {
-                concurrentPresences.removeFirst();
-            }
+            concurrentPresences.removeIf(it->it.getUntilLocal() != null &&
+                    (it.getUntilLocal().isBefore(presence.getSinceLocal())
+            || it.getUntilLocal().isEqual(presence.getSinceLocal())));
             concurrentPresences.add(presence);
             if (concurrentPresences.size() > maxPresences) {
                 return false;
@@ -117,8 +146,58 @@ public class PeopleHandlingBehaviour extends RequestProcessingBehaviour {
         return true;
     }
 
+    private void reconstructMeetings() {
+        if(presences.isEmpty()) context.setMeetings(Collections.emptyList());
+        //list of all points in time in which set of people present could change
+        List<LocalDateTime> presenceChangeTimes = Stream.concat(
+                presences.stream().map(Presence::getSinceLocal),
+                presences.stream().map(Presence::getUntilLocal).filter(Objects::nonNull)
+        ).distinct().collect(Collectors.toList());
+        //at each index set of people that are in the room from time presenceChangeTimes[i]
+        //to presenceChangeTimes[i+1] (or till infinity in case of last element)
+        List<List<AID>> peopleInRoomSinceChangeTime = presenceChangeTimes.stream()
+                .map(dt->new ArrayList<AID>()).collect(Collectors.toList());
+
+        int presenceChangeTimeBeginIndex = 0;
+        for(Presence presence : presences) {
+            //skip all timeslots which for sure won't have more people
+            while(presenceChangeTimes.get(presenceChangeTimeBeginIndex).isBefore(presence.getSinceLocal())) {
+                presenceChangeTimeBeginIndex++;
+            }
+            //add person to all timeslots which are part of presence
+            for(int presenceChangeTimeIndex = presenceChangeTimeBeginIndex;
+                presenceChangeTimeIndex < presenceChangeTimes.size()
+                        && (presence.getUntilLocal() == null
+            || presenceChangeTimes.get(presenceChangeTimeIndex).isBefore(presence.getUntilLocal()));
+                presenceChangeTimeIndex++) {
+                peopleInRoomSinceChangeTime.get(presenceChangeTimeIndex).add(presence.getPerson());
+            }
+        }
+        List<Meeting> newMeetings = new ArrayList<>();
+        //todo calculate temperature to maintain from db
+        for(int i = 0; i < peopleInRoomSinceChangeTime.size()-1; i++) {
+            if(!peopleInRoomSinceChangeTime.get(peopleInRoomSinceChangeTime.size()-1).isEmpty()) {
+                newMeetings.add(new Meeting(
+                        "",
+                        presenceChangeTimes.get(i),
+                        presenceChangeTimes.get(i + 1),
+                        peopleInRoomSinceChangeTime.get(i).size(),
+                        273 + 21));
+            }
+        }
+        if(!peopleInRoomSinceChangeTime.get(presenceChangeTimes.size()-1).isEmpty()) {
+            newMeetings.add(new Meeting("",
+                    presenceChangeTimes.get(presenceChangeTimes.size()-1),
+                    //LocalDateTime.MAX here causes log overflow in jade message creation
+                    presenceChangeTimes.get(presenceChangeTimes.size()-1).plusYears(5),
+                    peopleInRoomSinceChangeTime.get(presenceChangeTimes.size()-1).size(),
+                    273+21));
+        }
+        context.setMeetings(newMeetings);
+    }
+
     @Override
-    protected MessageTemplate getTemplate() {
+    public MessageTemplate getTemplate() {
         return template;
     }
 

--- a/src/main/java/hvac/roomcoordinator/behaviours/UpkeeperManagingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/UpkeeperManagingBehaviour.java
@@ -9,17 +9,14 @@ import jade.content.lang.Codec;
 import jade.content.onto.OntologyException;
 import jade.core.Agent;
 import jade.core.behaviours.TickerBehaviour;
-import jade.domain.FIPANames;
 import jade.lang.acl.ACLMessage;
 import jade.lang.acl.MessageTemplate;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class RoomCoordinatorTickerBehaviour extends TickerBehaviour {
+public class UpkeeperManagingBehaviour extends TickerBehaviour {
     private final RoomContext roomContext;
     private List<Meeting> pendingMeetingsInUpkeeper = new ArrayList<>();
     private List<Meeting> meetingsInUpkeeper = new ArrayList<>();
@@ -31,7 +28,7 @@ public class RoomCoordinatorTickerBehaviour extends TickerBehaviour {
         AWAITING_UPKEEPER_RESPONSE
     }
 
-    public RoomCoordinatorTickerBehaviour(Agent a, long period, RoomContext roomContext) {
+    public UpkeeperManagingBehaviour(Agent a, long period, RoomContext roomContext) {
         super(a, period);
         this.roomContext = roomContext;
         upkeeperTemplate = MessageTemplate.MatchSender(roomContext.getMyRoomUpkeeper());

--- a/src/main/java/hvac/roomcoordinator/behaviours/UpkeeperManagingBehaviour.java
+++ b/src/main/java/hvac/roomcoordinator/behaviours/UpkeeperManagingBehaviour.java
@@ -87,4 +87,8 @@ public class UpkeeperManagingBehaviour extends TickerBehaviour {
             reset(standardPeriod);
         }
     }
+
+    public MessageTemplate getTemplate() {
+        return upkeeperTemplate;
+    }
 }

--- a/src/main/java/hvac/roomupkeeper/behaviours/ConditionsReceivingBehaviour.java
+++ b/src/main/java/hvac/roomupkeeper/behaviours/ConditionsReceivingBehaviour.java
@@ -6,13 +6,13 @@ import hvac.ontologies.meeting.Meeting;
 import hvac.ontologies.meeting.MeetingOntology;
 import hvac.roomupkeeper.RoomUpkeeperContext;
 import hvac.util.Conversions;
+import hvac.util.behaviours.RequestProcessingBehaviour;
 import jade.content.Concept;
 import jade.content.ContentElement;
 import jade.content.lang.Codec;
 import jade.content.onto.OntologyException;
 import jade.content.onto.basic.Action;
 import jade.core.Agent;
-import jade.core.behaviours.CyclicBehaviour;
 import jade.domain.FIPANames;
 import jade.lang.acl.ACLMessage;
 import jade.lang.acl.MessageTemplate;
@@ -20,7 +20,9 @@ import jade.lang.acl.MessageTemplate;
 import java.util.Comparator;
 import java.util.List;
 
-public class ConditionsReceivingBehaviour extends CyclicBehaviour {
+import static hvac.util.SimpleReplies.*;
+
+public class ConditionsReceivingBehaviour extends RequestProcessingBehaviour {
     private final RoomUpkeeperContext context;
     private final MessageTemplate messageTemplate = MessageTemplate.and(
             MessageTemplate.MatchOntology(MeetingOntology.getInstance().getName()),
@@ -28,33 +30,12 @@ public class ConditionsReceivingBehaviour extends CyclicBehaviour {
     );
 
     public ConditionsReceivingBehaviour(Agent a, RoomUpkeeperContext context) {
-        super(a);
+        super(a, context.getLogger());
         this.context = context;
     }
 
     @Override
-    public void action() {
-        ACLMessage msg = myAgent.receive(messageTemplate);
-        if(msg != null) {
-            if(msg.getPerformative() == ACLMessage.REQUEST) {
-                try {
-                    processRequest(msg);
-                } catch (Codec.CodecException | OntologyException e) {
-                    context.getLogger().log("message not understood: "
-                            + msg + ", exception: " + e.getMessage());
-                    replyNotUnderstood(msg);
-                }
-            } else {
-                context.getLogger().log("message not understood: "
-                        + msg + ", not a request");
-                replyNotUnderstood(msg);
-            }
-        } else {
-            block();
-        }
-    }
-
-    private void processRequest(ACLMessage msg) throws Codec.CodecException, OntologyException {
+    protected void processRequest(ACLMessage msg) throws Codec.CodecException, OntologyException {
         ContentElement ce = myAgent.getContentManager().extractContent(msg);
         if (ce instanceof Action) {
             Concept action = ((Action) ce).getAction();
@@ -65,38 +46,25 @@ public class ConditionsReceivingBehaviour extends CyclicBehaviour {
                 for(int i = 0; i <conditions.size()-1; i++) {
                     if(Conversions.toLocalDateTime(conditions.get(i).getEndDate())
                             .isAfter(Conversions.toLocalDateTime(conditions.get(i+1).getStartDate()))) {
-                        replyRefuse(msg);
-                        context.getLogger().log("refused to mantain conditions: "
+                        replyRefuse(myAgent, msg);
+                        context.getLogger().log("refused to maintain conditions: "
                                 + Joiner.on(", ").join(conditions)+", periods not mutually exclusive");
                         return;
                     }
                 }
-                replyAgree(msg);
-                context.getLogger().log("agreed to mantain conditions: "
+                replyAgree(myAgent, msg);
+                context.getLogger().log("agreed to maintain conditions: "
                         + Joiner.on(", ").join(conditions));
                 context.setMeetingQueue(conditions);
                 return;
             }
         }
         context.getLogger().log("message not understood: " + msg);
-        replyNotUnderstood(msg);
+        replyNotUnderstood(myAgent, msg);
     }
 
-    private void replyAgree(ACLMessage msg) {
-        ACLMessage reply = msg.createReply();
-        reply.setPerformative(ACLMessage.AGREE);
-        myAgent.send(reply);
-    }
-
-    private void replyRefuse(ACLMessage msg) {
-        ACLMessage reply = msg.createReply();
-        reply.setPerformative(ACLMessage.REFUSE);
-        myAgent.send(reply);
-    }
-
-    private void replyNotUnderstood(ACLMessage msg) {
-        ACLMessage reply = msg.createReply();
-        reply.setPerformative(ACLMessage.NOT_UNDERSTOOD);
-        myAgent.send(reply);
+    @Override
+    protected MessageTemplate getTemplate() {
+        return messageTemplate;
     }
 }

--- a/src/main/java/hvac/simulation/rooms/Room.java
+++ b/src/main/java/hvac/simulation/rooms/Room.java
@@ -5,12 +5,14 @@ public class Room {
     private final int seats;
     private final float volume;//in m3
     private final float area;//in m2
-    public Room(int id, int seats, float volume, float area)
+    private final boolean meetingRoom;
+    public Room(int id, int seats, float volume, float area, boolean meetingRoom)
     {
         this.id = id;
         this.seats = seats;
         this.volume = volume;
         this.area = area;
+        this.meetingRoom = meetingRoom;
     }
 
     public int getId() {
@@ -25,5 +27,7 @@ public class Room {
     public float getArea() {
         return area;
     }
-
+    public boolean isMeetingRoom() {
+        return meetingRoom;
+    }
 }

--- a/src/main/java/hvac/util/Conversions.java
+++ b/src/main/java/hvac/util/Conversions.java
@@ -14,11 +14,13 @@ import java.util.stream.Collectors;
 
 public class Conversions {
     public static LocalDateTime toLocalDateTime(Date date) {
+        if(date == null) return null;
         return date.toInstant()
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
     }
     public static Date toDate(LocalDateTime date) {
+        if(date == null) return null;
         return Date.from(date.atZone(ZoneId.systemDefault()).toInstant());
     }
 

--- a/src/main/java/hvac/util/Helpers.java
+++ b/src/main/java/hvac/util/Helpers.java
@@ -18,10 +18,10 @@ import java.util.function.Consumer;
 
 public class Helpers {
     public static void loadMap(RoomMap roomMap){
-        Room r1 = new Room(1,2,200, 50);
-        Room r2 = new Room(2,2,250, 70);
-        Room r3 = new Room(3,3,150, 35);
-        Room r4 = new Room(4,3,300, 80);
+        Room r1 = new Room(1,2,200, 50, false);
+        Room r2 = new Room(2,2,250, 70, true);
+        Room r3 = new Room(3,3,150, 35, false);
+        Room r4 = new Room(4,3,300, 80, true);
         RoomWall r12 = new RoomWall(24, 0.4f);
         RoomWall r23 = new RoomWall(16, 0.2f);
         RoomWall r34 = new RoomWall(18, 0.5f);

--- a/src/main/java/hvac/util/SimpleReplies.java
+++ b/src/main/java/hvac/util/SimpleReplies.java
@@ -1,0 +1,25 @@
+package hvac.util;
+
+import jade.core.Agent;
+import jade.lang.acl.ACLMessage;
+
+public class SimpleReplies {
+
+    public static void replyAgree(Agent myAgent, ACLMessage msg) {
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.AGREE);
+        myAgent.send(reply);
+    }
+
+    public static void replyRefuse(Agent myAgent, ACLMessage msg) {
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.REFUSE);
+        myAgent.send(reply);
+    }
+
+    public static void replyNotUnderstood(Agent myAgent, ACLMessage msg) {
+        ACLMessage reply = msg.createReply();
+        reply.setPerformative(ACLMessage.NOT_UNDERSTOOD);
+        myAgent.send(reply);
+    }
+}

--- a/src/main/java/hvac/util/behaviours/NotUnderstoodBehaviour.java
+++ b/src/main/java/hvac/util/behaviours/NotUnderstoodBehaviour.java
@@ -1,0 +1,41 @@
+package hvac.util.behaviours;
+
+import hvac.util.Logger;
+import jade.core.Agent;
+import jade.core.behaviours.CyclicBehaviour;
+import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
+
+import static hvac.util.SimpleReplies.replyNotUnderstood;
+
+public class NotUnderstoodBehaviour extends CyclicBehaviour {
+    private final Logger logger;
+    private final MessageTemplate template;
+    public NotUnderstoodBehaviour(Agent a, Logger logger, MessageTemplate ... templatesToIgnore) {
+        super(a);
+        this.logger = logger;
+        template = constructIgnoreTemplate(templatesToIgnore);
+    }
+
+    private MessageTemplate constructIgnoreTemplate(MessageTemplate[] templatesToIgnore) {
+        MessageTemplate res = MessageTemplate.MatchAll();
+        for (MessageTemplate templateToIgnore :
+                templatesToIgnore) {
+            res = MessageTemplate.and(res, MessageTemplate.not(templateToIgnore));
+        }
+        return res;
+    }
+
+    @Override
+    public void action() {
+        ACLMessage msg = myAgent.receive(template);
+        if(msg != null) {
+            if(msg.getPerformative() != ACLMessage.NOT_UNDERSTOOD) {
+                logger.log("received unexpected message: " + msg);
+                replyNotUnderstood(myAgent, msg);
+            }
+        } else {
+            block();
+        }
+    }
+}

--- a/src/main/java/hvac/util/behaviours/RequestProcessingBehaviour.java
+++ b/src/main/java/hvac/util/behaviours/RequestProcessingBehaviour.java
@@ -1,0 +1,45 @@
+package hvac.util.behaviours;
+
+import hvac.util.Logger;
+import jade.content.lang.Codec;
+import jade.content.onto.OntologyException;
+import jade.core.Agent;
+import jade.core.behaviours.CyclicBehaviour;
+import jade.lang.acl.ACLMessage;
+import jade.lang.acl.MessageTemplate;
+
+import static hvac.util.SimpleReplies.replyNotUnderstood;
+
+public abstract class RequestProcessingBehaviour extends CyclicBehaviour {
+    private final Logger logger;
+
+    public RequestProcessingBehaviour(Agent myAgent, Logger logger) {
+        super(myAgent);
+
+        this.logger = logger;
+    }
+
+    @Override
+    public final void action() {
+        ACLMessage msg = myAgent.receive(getTemplate());
+        if(msg != null) {
+            if(msg.getPerformative() == ACLMessage.REQUEST) {
+                try {
+                    processRequest(msg);
+                } catch (Codec.CodecException | OntologyException e) {
+                    logger.log("not understood (parse exception):" + msg);
+                    e.printStackTrace();
+                    replyNotUnderstood(myAgent, msg);
+                }
+            } else {
+                logger.log("not understood (not a request):" + msg);
+                replyNotUnderstood(myAgent, msg);
+            }
+        } else {
+            block();
+        }
+    }
+
+    protected abstract void processRequest(ACLMessage msg) throws Codec.CodecException, OntologyException;
+    protected abstract MessageTemplate getTemplate();
+}

--- a/src/main/java/hvac/weatherforecaster/WeatherForecasterAgent.java
+++ b/src/main/java/hvac/weatherforecaster/WeatherForecasterAgent.java
@@ -4,6 +4,7 @@ import hvac.database.Connection;
 import hvac.database.entities.WeatherSnapshot;
 import hvac.ontologies.weather.WeatherOntology;
 import hvac.time.DateTimeSimulator;
+import hvac.util.Logger;
 import hvac.util.df.DfHelpers;
 import hvac.weather.DatabaseForecastProvider;
 import hvac.weather.interfaces.ForecastProvider;
@@ -32,8 +33,10 @@ public class WeatherForecasterAgent extends Agent {
         Connection database = new Connection();
         ForecastProvider provider = new DatabaseForecastProvider(database);
         int weatherGettingSpeed = (int)(1000*3600/DateTimeSimulator.getTimeScale());
+        Logger logger = new Logger();
+        logger.setAgentName("weather-forecaster");
         addBehaviour(new WeatherGettingBehaviour(this, weatherGettingSpeed, provider, oneWeekPlusWeather));
-        addBehaviour(new ForecastProvidingBehaviour(this, oneWeekPlusWeather));
+        addBehaviour(new ForecastProvidingBehaviour(this, oneWeekPlusWeather, logger));
     }
 
     private void usage(String err) {


### PR DESCRIPTION
Added new variant of room coordinator - one that manages rooms that don't host meetings but are work rooms - which people can enter and leave. It can accept messages from people that they will enter or leave the room at given hour and ensures that there won't be too many people in the room at the same time. It can handle two types of messages: 

- requestCurrentPresences - in response he will send a list of presences (since this time, until this time this person will be in this room, until can be null)

- requestAddPresence - he will add information that this person enters this room at this hour and/or leaves at this hour
There can't be more than one presence per person per room. If there is presence with no end time, person can't send presence with only end time and then presence with no end time will be updated
If there isn't any presence for that person in that room - presence with only end time cannot be send.

Functions creating messages to be used in Personal Agent are in the RoomCoordinatorAgentMessenger class
closes #24 